### PR TITLE
Allow url

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ human-facing version number. See [SemVer](https://semver.org/).
 
 4. **Load your snapshot**:
    - Use the file picker to load a local JSON file
-   - Or use `?file=./snapshot.json` query parameter
+   - Or use `?snapshotUrl=./snapshot.json` (alias: `?file=...`)
+   - For presigned URLs (recommended): use
+     `?snapshotUrlB64=<base64url(utf8(url))>`
    - Or click "Load ./snapshot.json" if you've placed the file in this directory
 
 ### Quick Start (GitHub Pages / PWA build)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A static HTML/JS/CSS viewer for exploring NEAT-AI creature snapshots. This is a
 debug tool for investigating why discovery candidates fail or succeed.
 
+[Example](https://stsoftwareau.github.io/NEAT-AI-Explore/?snapshotUrlB64=aHR0cHM6Ly9ncnEtYXAtc291dGhlYXN0LTIuczMuYXAtc291dGhlYXN0LTIuYW1hem9uYXdzLmNvbS9ORUFULUFJLUV4cGxvcmUvc25hcHNob3RzLzIwMjUxMjE5VDA0MzgwM1pfZDIzYTM2OGMtODYxNy01NzliLWJiNWMtNmFmMjJhMTA2YmJjLnNuYXBzaG90Lmpzb24uZ3o_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BU0lBVE9NVEhCWFRQWVFDWFJJUCUyRjIwMjUxMjE5JTJGYXAtc291dGhlYXN0LTIlMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUxMjE5VDA0MzgyM1omWC1BbXotRXhwaXJlcz02MDQ4MDAmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JlgtQW16LVNlY3VyaXR5LVRva2VuPUlRb0piM0pwWjJsdVgyVmpFTjMlMkYlMkYlMkYlMkYlMkYlMkYlMkYlMkYlMkYlMkZ3RWFEbUZ3TFhOdmRYUm9aV0Z6ZEMweUlrZ3dSZ0loQU9KbXRkZjNObzRuOXhmYjBtcnlLa1ZQNnJ6S3F0c0YlMkYyaUVPV3dFd1E0WEFpRUF0aU9vamVBVG9jdzhYa3RwUjRnZlpxMU1CdiUyRlZLWlFVJTJGdW1XQzNKOWRqd3FvZ0lJcHYlMkYlMkYlMkYlMkYlMkYlMkYlMkYlMkYlMkYlMkZBUkFDR2d3eU16Y3dOamc0TVRVNE5EWWlESWxvZURFbVM4eXU2enBSRnlyMkFmTDBpV1olMkY2TjZNMklRQnJBRGtVb3VtVGVlSEdtckFucmhydEdqaE9heTNMRnk3ODhneTlmdVVGcFFiaVc4aHdWM1VETVQlMkJ5Zks0YTA5T28yVSUyQktra1k3Qk13ZHJBbkF3bWZ1a3hPUE1mWnV2eU1ZJTJCalV4OFZaQ09rWEZyeDlHZTFNRkpIYkJuTUpmd1ZpMlBwQnZNbE41YzhZV0FHbG90TEFDamJVZ3M2bUJ0bnJwWlhIMWNDUlhSNTc2VXVHOGFXVFRmQk42Z1hVcldzZ01peDdWTTl6dks2dG1ndU53eVJmZlU1akxFMEx4SEVVU0ZVY29xV09UeGdBS2p1UU9TYkg5cG83NjNBWXJ3ZG1BYUVoNWxubkx0ZnFrdlg2ZmRWVDZhdVhURnBWNjJJYUtsODJkVmMxU2MlMkY1S0lWZDNmY1lObVZIOUREVXJKUEtCanFjQVdUYTYwUEp3UnFjd3dOV2JLWDd1MEdFRG1WSmo0RU1vNmY4WDVCbFBrSTE5T2ZKWTFoTmRTa2Z1bWMxd0h6OXg2N3RucSUyRmNlemxNVWpScXVURjI0MUNHRnBpOU1VQ0VxNmkwWXlTeHRMcGpraER5NEdFMU5UYW14SlZYSDB1U1FxRlFIYkVnYXZGVCUyQjNHclN0WEZZRzlrejFXd2RkeDdyR1ljZkYlMkJxcjk4M2FuRWRIaGJJaHJFQnQ4JTJGRnMlMkI5aTRzTnh0OEZ4cldyS0N1TjhOdyUzRCUzRCZYLUFtei1TaWduYXR1cmU9ODM1NTAwZDNkNDc0Yjk3ODgzODIzZjI4MDk0ZDBiYzc3ODJiMTBhM2FjYTY4Mjk5NjA2NmZiMzhlNmY2ZmFiYw)
 ## GitHub Pages + PWA
 
 This repo is configured to deploy a **Progressive Web App (PWA)** to **GitHub
@@ -56,6 +57,24 @@ human-facing version number. See [SemVer](https://semver.org/).
    - For presigned URLs (recommended): use
      `?snapshotUrlB64=<base64url(utf8(url))>`
    - Or click "Load ./snapshot.json" if you've placed the file in this directory
+
+### Loading snapshots from S3 (presigned URLs)
+
+If you load a snapshot via a presigned S3 URL from GitHub Pages, the S3 bucket
+must allow **CORS** for the GitHub Pages origin, otherwise the browser will
+block the request.
+
+- **Allowed origin**: `https://stsoftwareau.github.io`
+- **Allowed methods**: `GET`, `HEAD`
+- **Allowed headers**: `*`
+
+Also note:
+
+- If you upload `snapshot.json.gz`, either:
+  - **Recommended**: set object metadata `Content-Encoding: gzip` and
+    `Content-Type: application/json` so browsers transparently decompress, or
+  - Ensure your browser supports `DecompressionStream` (the app will decompress
+    `.gz` client-side when possible).
 
 ### Quick Start (GitHub Pages / PWA build)
 

--- a/app.js
+++ b/app.js
@@ -168,8 +168,44 @@ function setStatus(msg, kind = "") {
 }
 
 async function fetchJson(url) {
-  const res = await fetch(url, { cache: "no-store" });
+  let res;
+  try {
+    res = await fetch(url, { cache: "no-store" });
+  } catch (e) {
+    // Browser blocks cross-origin fetches without CORS headers (common with S3 presigned URLs).
+    // fetch() rejects with TypeError("Failed to fetch") in that case.
+    if (e?.message === "Failed to fetch") {
+      throw new Error(
+        "Failed to fetch (likely CORS). If this is an S3 presigned URL, add a bucket CORS rule allowing origin https://stsoftwareau.github.io (GET/HEAD).",
+      );
+    }
+    throw e;
+  }
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+  const ce = (res.headers.get("content-encoding") ?? "").toLowerCase();
+  const ct = (res.headers.get("content-type") ?? "").toLowerCase();
+  const looksGz = String(url).toLowerCase().includes(".gz") ||
+    ct.includes("gzip") || ct.includes("application/x-gzip");
+
+  // If S3 serves Content-Encoding: gzip then fetch transparently decompresses and res.json() works.
+  if (ce.includes("gzip")) return res.json();
+
+  // If the object is a raw .gz payload (no Content-Encoding), decompress in-browser.
+  if (looksGz) {
+    if (typeof DecompressionStream === "undefined") {
+      throw new Error(
+        "Snapshot appears to be gzipped (.gz) but this browser can't decompress it. Re-upload with Content-Encoding: gzip and Content-Type: application/json, or upload an uncompressed .json.",
+      );
+    }
+    const buf = await res.arrayBuffer();
+    const stream = new Blob([buf]).stream().pipeThrough(
+      new DecompressionStream("gzip"),
+    );
+    const text = await new Response(stream).text();
+    return JSON.parse(text);
+  }
+
   return res.json();
 }
 
@@ -968,8 +1004,23 @@ el.fileInput.onchange = async () => {
   if (!file) return;
   try {
     setStatus(`Reading ${file.name}...`);
-    const text = await file.text();
-    const obj = JSON.parse(text);
+    let obj;
+    if (file.name.toLowerCase().endsWith(".gz")) {
+      if (typeof DecompressionStream === "undefined") {
+        throw new Error(
+          "This snapshot is gzipped (.gz) but this browser can't decompress it. Export/upload an uncompressed .json, or use a browser with DecompressionStream support.",
+        );
+      }
+      const buf = await file.arrayBuffer();
+      const stream = new Blob([buf]).stream().pipeThrough(
+        new DecompressionStream("gzip"),
+      );
+      const text = await new Response(stream).text();
+      obj = JSON.parse(text);
+    } else {
+      const text = await file.text();
+      obj = JSON.parse(text);
+    }
     await loadSnapshot(obj, file.name);
   } catch (e) {
     setStatus(e.message, "bad");

--- a/app.js
+++ b/app.js
@@ -995,10 +995,47 @@ el.fetchUrl.onkeydown = (e) => {
 
 loadInputLabels().then(() => {
   const params = new URLSearchParams(window.location.search);
-  const fileParam = params.get("file");
-  if (fileParam) {
-    el.fetchUrl.value = fileParam;
-    loadSnapshot(fileParam, fileParam);
+  const snapshotUrlB64Param = params.get("snapshotUrlB64");
+  const snapshotUrlParam = params.get("snapshotUrl") ?? params.get("url") ??
+    params.get("file");
+
+  function decodeBase64UrlToUtf8(base64Url) {
+    // Base64url decode for query params (avoids needing to percent-encode presigned URLs).
+    // See RFC 4648 §5.
+    try {
+      const base64 = base64Url.replaceAll("-", "+").replaceAll("_", "/");
+      const pad = "=".repeat((4 - (base64.length % 4)) % 4);
+      const bin = atob(base64 + pad);
+      const bytes = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+      return new TextDecoder().decode(bytes);
+    } catch (_e) {
+      return null;
+    }
+  }
+
+  function isDangerousUrlScheme(s) {
+    const v = String(s ?? "").trim().toLowerCase();
+    return v.startsWith("javascript:") || v.startsWith("data:");
+  }
+
+  let initialUrl = null;
+  let initialLabel = null;
+
+  if (snapshotUrlB64Param) {
+    const decoded = decodeBase64UrlToUtf8(snapshotUrlB64Param);
+    if (decoded && !isDangerousUrlScheme(decoded)) {
+      initialUrl = decoded;
+      initialLabel = decoded;
+    }
+  } else if (snapshotUrlParam && !isDangerousUrlScheme(snapshotUrlParam)) {
+    initialUrl = snapshotUrlParam;
+    initialLabel = snapshotUrlParam;
+  }
+
+  if (initialUrl) {
+    el.fetchUrl.value = initialUrl;
+    loadSnapshot(initialUrl, initialLabel ?? initialUrl);
   } else {
     setStatus("Enter URL or browse for a snapshot JSON");
   }

--- a/docs/app.js
+++ b/docs/app.js
@@ -1008,10 +1008,47 @@ el.fetchUrl.onkeydown = (e) => {
 
 loadInputLabels().then(() => {
   const params = new URLSearchParams(window.location.search);
-  const fileParam = params.get("file");
-  if (fileParam) {
-    el.fetchUrl.value = fileParam;
-    loadSnapshot(fileParam, fileParam);
+  const snapshotUrlB64Param = params.get("snapshotUrlB64");
+  const snapshotUrlParam = params.get("snapshotUrl") ?? params.get("url") ??
+    params.get("file");
+
+  function decodeBase64UrlToUtf8(base64Url) {
+    // Base64url decode for query params (avoids needing to percent-encode presigned URLs).
+    // See RFC 4648 §5.
+    try {
+      const base64 = base64Url.replaceAll("-", "+").replaceAll("_", "/");
+      const pad = "=".repeat((4 - (base64.length % 4)) % 4);
+      const bin = atob(base64 + pad);
+      const bytes = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+      return new TextDecoder().decode(bytes);
+    } catch (_e) {
+      return null;
+    }
+  }
+
+  function isDangerousUrlScheme(s) {
+    const v = String(s ?? "").trim().toLowerCase();
+    return v.startsWith("javascript:") || v.startsWith("data:");
+  }
+
+  let initialUrl = null;
+  let initialLabel = null;
+
+  if (snapshotUrlB64Param) {
+    const decoded = decodeBase64UrlToUtf8(snapshotUrlB64Param);
+    if (decoded && !isDangerousUrlScheme(decoded)) {
+      initialUrl = decoded;
+      initialLabel = decoded;
+    }
+  } else if (snapshotUrlParam && !isDangerousUrlScheme(snapshotUrlParam)) {
+    initialUrl = snapshotUrlParam;
+    initialLabel = snapshotUrlParam;
+  }
+
+  if (initialUrl) {
+    el.fetchUrl.value = initialUrl;
+    loadSnapshot(initialUrl, initialLabel ?? initialUrl);
   } else {
     setStatus("Enter URL or browse for a snapshot JSON");
   }

--- a/docs/app.js
+++ b/docs/app.js
@@ -168,8 +168,44 @@ function setStatus(msg, kind = "") {
 }
 
 async function fetchJson(url) {
-  const res = await fetch(url, { cache: "no-store" });
+  let res;
+  try {
+    res = await fetch(url, { cache: "no-store" });
+  } catch (e) {
+    // Browser blocks cross-origin fetches without CORS headers (common with S3 presigned URLs).
+    // fetch() rejects with TypeError("Failed to fetch") in that case.
+    if (e?.message === "Failed to fetch") {
+      throw new Error(
+        "Failed to fetch (likely CORS). If this is an S3 presigned URL, add a bucket CORS rule allowing origin https://stsoftwareau.github.io (GET/HEAD).",
+      );
+    }
+    throw e;
+  }
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+  const ce = (res.headers.get("content-encoding") ?? "").toLowerCase();
+  const ct = (res.headers.get("content-type") ?? "").toLowerCase();
+  const looksGz = String(url).toLowerCase().includes(".gz") ||
+    ct.includes("gzip") || ct.includes("application/x-gzip");
+
+  // If S3 serves Content-Encoding: gzip then fetch transparently decompresses and res.json() works.
+  if (ce.includes("gzip")) return res.json();
+
+  // If the object is a raw .gz payload (no Content-Encoding), decompress in-browser.
+  if (looksGz) {
+    if (typeof DecompressionStream === "undefined") {
+      throw new Error(
+        "Snapshot appears to be gzipped (.gz) but this browser can't decompress it. Re-upload with Content-Encoding: gzip and Content-Type: application/json, or upload an uncompressed .json.",
+      );
+    }
+    const buf = await res.arrayBuffer();
+    const stream = new Blob([buf]).stream().pipeThrough(
+      new DecompressionStream("gzip"),
+    );
+    const text = await new Response(stream).text();
+    return JSON.parse(text);
+  }
+
   return res.json();
 }
 
@@ -981,8 +1017,23 @@ el.fileInput.onchange = async () => {
   if (!file) return;
   try {
     setStatus(`Reading ${file.name}...`);
-    const text = await file.text();
-    const obj = JSON.parse(text);
+    let obj;
+    if (file.name.toLowerCase().endsWith(".gz")) {
+      if (typeof DecompressionStream === "undefined") {
+        throw new Error(
+          "This snapshot is gzipped (.gz) but this browser can't decompress it. Export/upload an uncompressed .json, or use a browser with DecompressionStream support.",
+        );
+      }
+      const buf = await file.arrayBuffer();
+      const stream = new Blob([buf]).stream().pipeThrough(
+        new DecompressionStream("gzip"),
+      );
+      const text = await new Response(stream).text();
+      obj = JSON.parse(text);
+    } else {
+      const text = await file.text();
+      obj = JSON.parse(text);
+    }
     await loadSnapshot(obj, file.name);
   } catch (e) {
     setStatus(e.message, "bad");

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
         <input
           id="fileInput"
           type="file"
-          accept="application/json"
+          accept="application/json,.json,.gz,application/gzip,application/x-gzip"
           style="display: none"
         />
         <button id="fileBtn" class="button">Browse…</button>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
         <input
           id="fileInput"
           type="file"
-          accept="application/json"
+          accept="application/json,.json,.gz,application/gzip,application/x-gzip"
           style="display: none"
         />
         <button id="fileBtn" class="button">Browse…</button>

--- a/tests/gzip_snapshot_support_test.ts
+++ b/tests/gzip_snapshot_support_test.ts
@@ -1,0 +1,25 @@
+function assert(condition: unknown, message?: string): asserts condition {
+  if (!condition) throw new Error(message ?? "Assertion failed");
+}
+
+function repoPath(...parts: string[]): string {
+  const url = new URL(import.meta.url);
+  const here = url.pathname;
+  // .../tests/gzip_snapshot_support_test.ts -> repo root
+  const root = here.replace(/\/tests\/gzip_snapshot_support_test\.ts$/, "");
+  return [root, ...parts].join("/");
+}
+
+Deno.test("app supports loading gzipped snapshots (.json.gz)", async () => {
+  for (const p of [repoPath("app.js"), repoPath("docs", "app.js")]) {
+    const js = await Deno.readTextFile(p);
+    assert(
+      js.includes('new DecompressionStream("gzip")'),
+      `Expected ${p} to use DecompressionStream('gzip') for .gz snapshots`,
+    );
+    assert(
+      js.includes(".arrayBuffer()"),
+      `Expected ${p} to read gz payloads via arrayBuffer()`,
+    );
+  }
+});

--- a/tests/snapshot_url_param_test.ts
+++ b/tests/snapshot_url_param_test.ts
@@ -1,0 +1,37 @@
+function assert(condition: unknown, message?: string): asserts condition {
+  if (!condition) throw new Error(message ?? "Assertion failed");
+}
+
+function repoPath(...parts: string[]): string {
+  const url = new URL(import.meta.url);
+  const here = url.pathname;
+  // .../tests/snapshot_url_param_test.ts -> repo root
+  const root = here.replace(/\/tests\/snapshot_url_param_test\.ts$/, "");
+  return [root, ...parts].join("/");
+}
+
+Deno.test("app supports snapshotUrl and snapshotUrlB64 query parameters", async () => {
+  for (const p of [repoPath("app.js"), repoPath("docs", "app.js")]) {
+    const js = await Deno.readTextFile(p);
+
+    // Backwards compat + new URL param name.
+    assert(
+      js.includes('params.get("file")'),
+      `Expected ${p} to continue supporting ?file=...`,
+    );
+    assert(
+      js.includes('params.get("snapshotUrl")'),
+      `Expected ${p} to support ?snapshotUrl=...`,
+    );
+
+    // Presigned URL safe transport.
+    assert(
+      js.includes('params.get("snapshotUrlB64")'),
+      `Expected ${p} to support ?snapshotUrlB64=...`,
+    );
+    assert(
+      js.includes("decodeBase64UrlToUtf8"),
+      `Expected ${p} to include base64url decode helper`,
+    );
+  }
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds .gz snapshot support (local and remote with in-browser decompression), clearer S3 CORS errors, updated file input to accept .gz, and README guidance; includes a test for gzip support.
> 
> - **Viewer (app.js, docs/app.js)**:
>   - Add support for gzipped snapshots: detect `Content-Encoding: gzip` or `.gz` and decompress via `DecompressionStream` (fallback error if unsupported).
>   - Improve fetch error handling with explicit CORS guidance for presigned S3 URLs.
> - **UI (index.html, docs/index.html)**:
>   - Update file input `accept` to include `.gz` and gzip MIME types.
> - **Docs (README.md)**:
>   - Add example URL and a section on loading from S3 with required CORS rules and gzip metadata recommendations.
> - **Tests**:
>   - New Deno test `tests/gzip_snapshot_support_test.ts` verifies gzip handling in `app.js` and `docs/app.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8c11a0de7a877ec6d782d05f4c6de6c8b9958c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->