### PR TITLE
Add summariseSeriesStats function for statistical analysis of numeric…

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -19,6 +19,7 @@ import {
   computeOutgoingProxyTerms,
   computePreActivations,
   computeSquashDerivativeStats,
+  summariseSeriesStats,
 } from "./impact_diagnostics.js";
 
 let SNAPSHOT = null;
@@ -31,6 +32,7 @@ let uuidToDescription = {}; // "input-N" -> "Tooltip description"
 let DIAG_PRE = new Map();
 let DIAG_SQUASH = new Map();
 let DIAG_PROXY = new Map();
+let DIAG_PRE_STATS = new Map();
 
 let lastInboundAllocation = null;
 let lastInboundToUuid = null;
@@ -54,6 +56,14 @@ const TOOLTIPS = {
   "Type": "Neuron type: input, hidden, output, or constant",
   "Squash": "Activation function applied to the weighted sum of inputs",
   "Bias": "Constant value added before the activation function",
+  "Pre-activation mean":
+    "Pre-activation (net input) mean across samples. Pre-activation is the value before the squash: z = bias + Σ(weighted inputs).",
+  "Pre-activation range":
+    "Minimum and maximum pre-activation (net input) observed before the squash is applied.",
+  "Pre-activation p99":
+    "Approximate 99th percentile of pre-activation (net input). Large magnitudes often indicate saturation/clamping or numerical blow-ups upstream.",
+  "Pre-activation |x| max":
+    "Maximum absolute pre-activation (net input). Useful for spotting extreme values that can explode errors.",
   "Impact":
     "Fraction of influence this neuron has on the final output (0-1). Values < 1e-8 are suspiciously low and should be prunable.",
   "Impact (proxy, grad)":
@@ -539,6 +549,12 @@ async function loadSnapshot(source, label) {
         derivedSynapses,
         recordingNeurons,
       });
+      DIAG_PRE_STATS = new Map(
+        Array.from(DIAG_PRE.entries()).map(([uuid, arr]) => [
+          uuid,
+          summariseSeriesStats(arr, { sampleSize: 512 }),
+        ]),
+      );
       DIAG_SQUASH = computeSquashDerivativeStats({
         neuronsByUuid,
         preActivations: DIAG_PRE,
@@ -553,6 +569,7 @@ async function loadSnapshot(source, label) {
     } catch (e) {
       console.warn("Impact diagnostics failed (non-fatal):", e);
       DIAG_PRE = new Map();
+      DIAG_PRE_STATS = new Map();
       DIAG_SQUASH = new Map();
       DIAG_PROXY = new Map();
     }
@@ -749,6 +766,17 @@ function renderCurrentNeuron(uuid) {
 
   // Impact diagnostics: show-your-working-style evidence for squash issues.
   if (!isInput) {
+    const preStats = DIAG_PRE_STATS.get(uuid);
+    if (preStats && preStats.n > 0) {
+      props.push(["Pre-activation mean", formatSig(preStats.mean, 4)]);
+      props.push([
+        "Pre-activation range",
+        `${formatSig(preStats.min, 4)} → ${formatSig(preStats.max, 4)}`,
+      ]);
+      props.push(["Pre-activation p99", formatSig(preStats.p99, 4)]);
+      props.push(["Pre-activation |x| max", formatSig(preStats.maxAbs, 4)]);
+    }
+
     const proxy = DIAG_PROXY.get(uuid);
     if (typeof proxy === "number" && isFinite(proxy)) {
       props.push(["Impact (proxy, grad)", formatSig(proxy, 3)]);
@@ -1283,7 +1311,8 @@ function escapeHtml(s) {
 
 function initTouchTooltips() {
   // iOS Safari/PWA does not reliably show `title` tooltips on tap.
-  // Provide press-and-hold tooltips on touch devices, without stealing normal taps.
+  // Provide tap + press-and-hold tooltips on touch devices, without stealing
+  // normal taps for unrelated controls.
   const isTouch = (() => {
     try {
       return (navigator.maxTouchPoints ?? 0) > 0 ||
@@ -1339,7 +1368,14 @@ function initTouchTooltips() {
   function findTooltipTarget(startEl) {
     let n = startEl;
     while (n && n !== document.body) {
-      if (n?.getAttribute && n.hasAttribute("title")) {
+      // Only treat known tooltip affordances as tooltip targets. Many controls
+      // (buttons, inputs) have titles but still need to behave normally on tap.
+      const isKnownTooltipEl = n.classList?.contains("hasTooltip") ||
+        n.classList?.contains("stat") ||
+        n.classList?.contains("neuronAlias") ||
+        n.classList?.contains("aliasName");
+
+      if (isKnownTooltipEl && n?.getAttribute && n.hasAttribute("title")) {
         const t = n.getAttribute("title");
         if (t && t.trim().length > 0) return n;
       }
@@ -1385,6 +1421,32 @@ function initTouchTooltips() {
     { passive: true, capture: true },
   );
 
+  // iPhone Safari can be inconsistent about long-press and `title`. Make tap the
+  // primary way to open tooltips for stat chips / labelled properties.
+  document.addEventListener(
+    "click",
+    (e) => {
+      const target = findTooltipTarget(e.target);
+      if (!target) return;
+
+      // Toggle: tapping the same target closes the tooltip.
+      if (
+        shownForTarget && target === shownForTarget &&
+        tooltipEl?.classList.contains("isOpen")
+      ) {
+        hideTouchTooltip();
+      } else {
+        shownForTarget = target;
+        showTouchTooltip(target.getAttribute("title"));
+      }
+
+      // Don't let the click bubble and trigger row navigation underneath.
+      e.preventDefault();
+      e.stopPropagation();
+    },
+    { capture: true },
+  );
+
   // If we just showed a tooltip, suppress the follow-up click so we don't
   // accidentally trigger navigation (e.g. tapping a stat inside a synapse row).
   document.addEventListener(
@@ -1410,6 +1472,18 @@ function initTouchTooltips() {
       hideTouchTooltip();
     },
     { passive: true },
+  );
+
+  // Some iOS flows fire `click` without a preceding touchstart (e.g., assistive
+  // tech). Support outside-click close as well.
+  document.addEventListener(
+    "click",
+    (e) => {
+      if (!tooltipEl?.classList.contains("isOpen")) return;
+      if (tooltipEl.contains(e.target)) return;
+      hideTouchTooltip();
+    },
+    { capture: true },
   );
 }
 

--- a/docs/app.js
+++ b/docs/app.js
@@ -19,6 +19,8 @@ import {
   computeOutgoingProxyTerms,
   computePreActivations,
   computeSquashDerivativeStats,
+  summariseDeadZoneStats,
+  summariseErrorConcentration,
   summariseSeriesStats,
 } from "./impact_diagnostics.js";
 
@@ -33,6 +35,18 @@ let DIAG_PRE = new Map();
 let DIAG_SQUASH = new Map();
 let DIAG_PROXY = new Map();
 let DIAG_PRE_STATS = new Map();
+let DIAG_DEADZONES = new Map();
+let DIAG_NONFINITE = new Map();
+let DIAG_ERROR_TAIL = new Map();
+let DIAG_INPUTS = {
+  constantInputs: [],
+  correlatedPairs: [],
+  candidateCoverage: [],
+};
+
+let DISCOVERY_CANDIDATES = [];
+let selectedCandidateKey = null;
+let currentNeuronTab = "details"; // details | issues | candidates
 
 let lastInboundAllocation = null;
 let lastInboundToUuid = null;
@@ -134,6 +148,12 @@ const el = {
   neuronProps: document.getElementById("neuronProps"),
   impactBreakdown: document.getElementById("impactBreakdown"),
   impactDiagnosticsPanel: document.getElementById("impactDiagnosticsPanel"),
+  neuronTabDetails: document.getElementById("neuronTabDetails"),
+  neuronTabIssues: document.getElementById("neuronTabIssues"),
+  neuronTabCandidates: document.getElementById("neuronTabCandidates"),
+  neuronTabPanelDetails: document.getElementById("neuronTabPanelDetails"),
+  neuronTabPanelIssues: document.getElementById("neuronTabPanelIssues"),
+  neuronTabPanelCandidates: document.getElementById("neuronTabPanelCandidates"),
   pathModal: document.getElementById("pathModal"),
   pathModalBackdrop: document.getElementById("pathModalBackdrop"),
   pathModalTitle: document.getElementById("pathModalTitle"),
@@ -566,14 +586,45 @@ async function loadSnapshot(source, label) {
         outputUuids: outputs.map((o) => o.uuid),
         iterations: 8,
       });
+
+      // Issues tab: cache cheap summaries so the UI stays snappy on large snapshots.
+      DIAG_DEADZONES = new Map(
+        Array.from(neuronsByUuid.entries()).map(([uuid, n]) => {
+          const pre = DIAG_PRE.get(uuid) ?? [];
+          return [uuid, summariseDeadZoneStats(n?.squash, pre)];
+        }),
+      );
+      DIAG_NONFINITE = computeNonFiniteIssues({
+        recording: SNAPSHOT?.recording ?? null,
+      });
+      DIAG_ERROR_TAIL = computeErrorConcentrationIssues({
+        recording: SNAPSHOT?.recording ?? null,
+      });
+      DISCOVERY_CANDIDATES = extractDiscoveryCandidates(SNAPSHOT);
+      DIAG_INPUTS = computeInputIssues({
+        recording: SNAPSHOT?.recording ?? null,
+        inputCount: creature.input ?? 0,
+        candidates: DISCOVERY_CANDIDATES,
+      });
     } catch (e) {
       console.warn("Impact diagnostics failed (non-fatal):", e);
       DIAG_PRE = new Map();
       DIAG_PRE_STATS = new Map();
       DIAG_SQUASH = new Map();
       DIAG_PROXY = new Map();
+      DIAG_DEADZONES = new Map();
+      DIAG_NONFINITE = new Map();
+      DIAG_ERROR_TAIL = new Map();
+      DIAG_INPUTS = {
+        constantInputs: [],
+        correlatedPairs: [],
+        candidateCoverage: [],
+      };
+      DISCOVERY_CANDIDATES = [];
     }
 
+    selectedCandidateKey = null;
+    currentNeuronTab = "details";
     trace = [];
     navigateTo(startUuid);
   } catch (e) {
@@ -844,6 +895,9 @@ function renderCurrentNeuron(uuid) {
 
   renderImpactBreakdown(uuid, impact);
   renderImpactDiagnosticsPanel(uuid, n.type);
+  renderIssuesPanel(uuid, n.type);
+  renderCandidatesPanel(uuid);
+  applyNeuronTabState();
 }
 
 function renderImpactDiagnosticsPanel(uuid, neuronType) {
@@ -1192,6 +1246,19 @@ function renderSynapseList(toUuid) {
   enriched.forEach((syn) => {
     const row = document.createElement("div");
     row.className = "synapseRow";
+    const selected = (DISCOVERY_CANDIDATES ?? []).find((c) =>
+      c?.key === selectedCandidateKey
+    );
+    if (
+      selected &&
+      String(selected.type ?? "").toLowerCase() ===
+        "split_synapse_insert_neuron" &&
+      selected.fromUuid === syn.fromUuid &&
+      selected.toUuid === syn.toUuid
+    ) {
+      // Candidate overlay: highlight the original edge to be replaced.
+      row.classList.add("candidateReplaceEdge");
+    }
     if (trace.includes(syn.fromUuid)) {
       row.classList.add("inTrace");
     }
@@ -1484,6 +1551,986 @@ function initTouchTooltips() {
     },
     { capture: true },
   );
+}
+
+// ============================================================================
+// Tabs: Details / Issues / Candidates
+// ============================================================================
+
+function applyNeuronTabState() {
+  const tab = currentNeuronTab;
+
+  const cfg = [
+    ["details", el.neuronTabDetails, el.neuronTabPanelDetails],
+    ["issues", el.neuronTabIssues, el.neuronTabPanelIssues],
+    ["candidates", el.neuronTabCandidates, el.neuronTabPanelCandidates],
+  ];
+
+  for (const [name, btn, panel] of cfg) {
+    if (btn) {
+      const active = name === tab;
+      btn.classList.toggle("isActive", active);
+      btn.setAttribute("aria-selected", active ? "true" : "false");
+    }
+    if (panel) {
+      panel.classList.toggle("isActive", name === tab);
+    }
+  }
+}
+
+function setNeuronTab(tab) {
+  const t = String(tab ?? "").toLowerCase();
+  if (t !== "details" && t !== "issues" && t !== "candidates") return;
+  currentNeuronTab = t;
+  applyNeuronTabState();
+}
+
+if (el.neuronTabDetails) {
+  el.neuronTabDetails.onclick = () => setNeuronTab("details");
+}
+if (el.neuronTabIssues) {
+  el.neuronTabIssues.onclick = () => setNeuronTab("issues");
+}
+if (el.neuronTabCandidates) {
+  el.neuronTabCandidates.onclick = () => setNeuronTab("candidates");
+}
+
+// ============================================================================
+// Issues tab computations (cached on snapshot load)
+// ============================================================================
+
+function extractDiscoveryCandidates(snapshot) {
+  // Discovery snapshots have varied schema across versions. Keep this defensive.
+  const candidates = snapshot?.derived?.candidates ??
+    snapshot?.derived?.discoveryCandidates ??
+    snapshot?.derived?.discovery_candidates ??
+    snapshot?.discovery?.candidates ??
+    snapshot?.discoveryCandidates ??
+    snapshot?.candidates ??
+    [];
+
+  const arr = Array.isArray(candidates) ? candidates : [];
+  return arr.map((c, idx) => normaliseCandidate(c, idx)).filter(Boolean);
+}
+
+function normaliseCandidate(raw, idx) {
+  if (!raw || typeof raw !== "object") return null;
+
+  const type = String(
+    raw.type ?? raw.kind ?? raw.candidateType ?? raw.candidate_type ?? "",
+  ).trim();
+
+  // Helper: safe nested getter by trying multiple field paths.
+  function pick(...paths) {
+    for (const p of paths) {
+      const v = p(raw);
+      if (v != null) return v;
+    }
+    return null;
+  }
+
+  function asStr(v) {
+    return typeof v === "string" && v.trim() ? v.trim() : null;
+  }
+
+  function asNum(v) {
+    return typeof v === "number" && isFinite(v) ? v : null;
+  }
+
+  const fromUuid = asStr(pick(
+    (o) => o.fromUuid,
+    (o) => o.from_uuid,
+    (o) => o.fromUUID,
+    (o) => o.synapse?.fromUuid,
+    (o) => o.synapse?.from_uuid,
+  ));
+  const toUuid = asStr(pick(
+    (o) => o.toUuid,
+    (o) => o.to_uuid,
+    (o) => o.toUUID,
+    (o) => o.synapse?.toUuid,
+    (o) => o.synapse?.to_uuid,
+  ));
+
+  const fromIndex = asNum(pick((o) => o.fromIndex, (o) => o.from_index));
+  const toIndex = asNum(pick((o) => o.toIndex, (o) => o.to_index));
+
+  const oldWeight = asNum(pick(
+    (o) => o.oldWeight,
+    (o) => o.old_weight,
+    (o) => o.weight,
+    (o) => o.synapse?.weight,
+  ));
+
+  // New weights: allow arrays or explicit fields.
+  const newWeightsArr = pick((o) => o.newWeights, (o) => o.new_weights);
+  const newWeightA = asNum(
+    pick(
+      (o) => Array.isArray(newWeightsArr) ? newWeightsArr[0] : null,
+      (o) => o.newWeightA,
+      (o) => o.new_weight_a,
+      (o) => o.w1,
+    ),
+  );
+  const newWeightB = asNum(
+    pick(
+      (o) => Array.isArray(newWeightsArr) ? newWeightsArr[1] : null,
+      (o) => o.newWeightB,
+      (o) => o.new_weight_b,
+      (o) => o.w2,
+    ),
+  );
+
+  const newNeuron = raw.newNeuron ?? raw.neuron ?? raw.insertedNeuron ??
+    raw.inserted_neuron ?? null;
+  const newNeuronSquash = asStr(
+    newNeuron?.squash ?? raw.newNeuronSquash ?? raw.new_neuron_squash,
+  );
+  const newNeuronBias = asNum(
+    newNeuron?.bias ?? raw.newNeuronBias ?? raw.new_neuron_bias,
+  );
+
+  const expectedScoreGain = asNum(
+    pick(
+      (o) => o.expectedScoreGain,
+      (o) => o.expected_score_gain,
+      (o) => o.scoreGain,
+    ),
+  );
+  const expectedImpact = asNum(pick((o) => o.expectedImpact, (o) => o.impact));
+  const comment = asStr(
+    pick((o) => o.comment, (o) => o.note, (o) => o.diagnostics),
+  );
+
+  const key = asStr(raw.id) ??
+    asStr(raw.uuid) ??
+    `${type || "candidate"}:${fromUuid ?? "?"}→${toUuid ?? "?"}:${idx}`;
+
+  return {
+    key,
+    type,
+    fromUuid,
+    toUuid,
+    fromIndex,
+    toIndex,
+    oldWeight,
+    newWeightA,
+    newWeightB,
+    newNeuronSquash,
+    newNeuronBias,
+    expectedScoreGain,
+    expectedImpact,
+    comment,
+    raw,
+  };
+}
+
+function computeNonFiniteIssues({ recording }) {
+  const obsIndices = recording?.obsIndices ?? recording?.obs_indices ?? null;
+  const neurons = recording?.neurons ?? {};
+  const out = new Map();
+
+  function obsAt(pos) {
+    if (Array.isArray(obsIndices) && pos >= 0 && pos < obsIndices.length) {
+      return obsIndices[pos];
+    }
+    return pos;
+  }
+
+  function scan1d(arr) {
+    if (!Array.isArray(arr)) return { count: 0, firstPos: null };
+    let count = 0;
+    let firstPos = null;
+    for (let i = 0; i < arr.length; i++) {
+      const v = arr[i];
+      if (typeof v === "number" && isFinite(v)) continue;
+      count += 1;
+      if (firstPos == null) firstPos = i;
+    }
+    return { count, firstPos };
+  }
+
+  function scan2d(arr) {
+    if (!Array.isArray(arr)) return { count: 0, firstPos: null };
+    let count = 0;
+    let firstPos = null;
+    for (let i = 0; i < arr.length; i++) {
+      const row = arr[i];
+      if (!Array.isArray(row)) continue;
+      for (let j = 0; j < row.length; j++) {
+        const v = row[j];
+        if (typeof v === "number" && isFinite(v)) continue;
+        count += 1;
+        if (firstPos == null) firstPos = i;
+      }
+    }
+    return { count, firstPos };
+  }
+
+  for (const [uuid, rec] of Object.entries(neurons)) {
+    if (!rec || typeof rec !== "object") continue;
+    const act = scan1d(rec.activation);
+    const val = scan1d(rec.value);
+    const err = scan2d(rec.errors);
+    const total = act.count + val.count + err.count;
+    if (total <= 0) continue;
+
+    out.set(uuid, {
+      total,
+      activation: {
+        count: act.count,
+        firstObsIndex: act.firstPos == null ? null : obsAt(act.firstPos),
+      },
+      value: {
+        count: val.count,
+        firstObsIndex: val.firstPos == null ? null : obsAt(val.firstPos),
+      },
+      errors: {
+        count: err.count,
+        firstObsIndex: err.firstPos == null ? null : obsAt(err.firstPos),
+      },
+    });
+  }
+
+  return out;
+}
+
+function computeErrorConcentrationIssues({ recording }) {
+  const obsIndices = recording?.obsIndices ?? recording?.obs_indices ?? null;
+  const neurons = recording?.neurons ?? {};
+  const out = new Map();
+
+  function obsAt(pos) {
+    if (Array.isArray(obsIndices) && pos >= 0 && pos < obsIndices.length) {
+      return obsIndices[pos];
+    }
+    return pos;
+  }
+
+  for (const [uuid, rec] of Object.entries(neurons)) {
+    if (!rec || typeof rec !== "object") continue;
+    const errors = rec.errors;
+    if (!Array.isArray(errors) || errors.length === 0) continue;
+
+    /** @type {number[]} */
+    const contrib = [];
+    for (let i = 0; i < errors.length; i++) {
+      const row = errors[i];
+      if (!Array.isArray(row) || row.length === 0) {
+        contrib.push(0);
+        continue;
+      }
+      let sum = 0;
+      let n = 0;
+      for (const e of row) {
+        if (typeof e !== "number" || !isFinite(e)) continue;
+        sum += e * e;
+        n += 1;
+      }
+      contrib.push(n > 0 ? sum / n : 0);
+    }
+
+    const s = summariseErrorConcentration(contrib, { topK: 8 });
+    if (s.total <= 0) continue;
+
+    out.set(uuid, {
+      total: s.total,
+      topK: s.topK.map((t) => ({
+        obsIndex: obsAt(t.index),
+        value: t.value,
+        shareOfTotal: t.shareOfTotal,
+      })),
+      topKShare: s.topKShare,
+    });
+  }
+
+  return out;
+}
+
+function computeInputIssues({ recording, inputCount, candidates }) {
+  const neurons = recording?.neurons ?? {};
+
+  // Near-constant inputs (std dev ~0).
+  const constantInputs = [];
+  for (let i = 0; i < (inputCount ?? 0); i++) {
+    const uuid = `input-${i}`;
+    const rec = neurons?.[uuid];
+    const series = rec?.activation ?? rec?.value ?? null;
+    if (!Array.isArray(series) || series.length === 0) continue;
+    const s = summariseSeriesStats(series, { sampleSize: 1024 });
+    if (s.n > 0 && s.std < 1e-6) {
+      constantInputs.push({ uuid, std: s.std, mean: s.mean });
+    }
+  }
+
+  // Highly correlated input pairs (guard-railed).
+  const correlatedPairs = computeTopInputCorrelations({
+    recording,
+    inputCount,
+    maxInputs: 80,
+    sampleSize: 512,
+    topK: 12,
+  });
+
+  // Candidate coverage for input-N nodes.
+  const coverage = [];
+  const counts = new Map();
+  const helpful = new Map();
+  const harmful = new Map();
+
+  for (const c of (Array.isArray(candidates) ? candidates : [])) {
+    const uuids = candidateReferencedInputUuids(c);
+    const gain = typeof c.expectedScoreGain === "number"
+      ? c.expectedScoreGain
+      : null;
+    for (const u of uuids) {
+      counts.set(u, (counts.get(u) ?? 0) + 1);
+      if (gain != null) {
+        if (gain >= 0) helpful.set(u, (helpful.get(u) ?? 0) + 1);
+        else harmful.set(u, (harmful.get(u) ?? 0) + 1);
+      }
+    }
+  }
+
+  for (let i = 0; i < (inputCount ?? 0); i++) {
+    const uuid = `input-${i}`;
+    coverage.push({
+      uuid,
+      count: counts.get(uuid) ?? 0,
+      helpful: helpful.get(uuid) ?? 0,
+      harmful: harmful.get(uuid) ?? 0,
+    });
+  }
+  coverage.sort((a, b) => (b.count ?? 0) - (a.count ?? 0));
+
+  return { constantInputs, correlatedPairs, candidateCoverage: coverage };
+}
+
+function candidateReferencedInputUuids(candidate) {
+  /** @type {Set<string>} */
+  const out = new Set();
+  const re = /^input-\d+$/;
+
+  function walk(x, depth) {
+    if (depth > 4) return; // guard rails (candidates should be shallow)
+    if (typeof x === "string") {
+      const s = x.trim();
+      if (re.test(s)) out.add(s);
+      return;
+    }
+    if (!x || typeof x !== "object") return;
+    if (Array.isArray(x)) {
+      for (const v of x) walk(v, depth + 1);
+      return;
+    }
+    for (const v of Object.values(x)) walk(v, depth + 1);
+  }
+
+  walk(candidate?.raw ?? candidate, 0);
+  return Array.from(out);
+}
+
+function computeTopInputCorrelations(
+  { recording, inputCount, maxInputs, sampleSize, topK },
+) {
+  const neurons = recording?.neurons ?? {};
+  const nInputs = Math.max(0, Math.floor(inputCount ?? 0));
+  const useInputs = Math.min(nInputs, Math.max(0, Math.floor(maxInputs ?? 80)));
+  if (useInputs < 2) return [];
+
+  const seriesByUuid = [];
+  for (let i = 0; i < useInputs; i++) {
+    const uuid = `input-${i}`;
+    const rec = neurons?.[uuid];
+    const series = rec?.activation ?? rec?.value ?? null;
+    if (Array.isArray(series) && series.length > 4) {
+      seriesByUuid.push({ uuid, series });
+    }
+  }
+  if (seriesByUuid.length < 2) return [];
+
+  // Downsample evenly to keep this fast.
+  function sampleSeries(arr) {
+    const take = Math.min(
+      arr.length,
+      Math.max(8, Math.floor(sampleSize ?? 512)),
+    );
+    if (take >= arr.length) return arr;
+    const step = arr.length / take;
+    const out = [];
+    for (let i = 0; i < take; i++) {
+      const idx = Math.min(arr.length - 1, Math.floor(i * step));
+      const v = arr[idx];
+      out.push(typeof v === "number" && isFinite(v) ? v : 0);
+    }
+    return out;
+  }
+
+  const sampled = seriesByUuid.map((s) => ({
+    uuid: s.uuid,
+    arr: sampleSeries(s.series),
+  }));
+
+  // Compute top correlations (|r| high).
+  const k = Math.max(1, Math.floor(topK ?? 12));
+  /** @type {{ a: string, b: string, r: number }[]} */
+  const top = [];
+
+  function insert(item) {
+    // keep ascending by |r|
+    const ar = Math.abs(item.r);
+    let lo = 0;
+    let hi = top.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (Math.abs(top[mid].r) <= ar) lo = mid + 1;
+      else hi = mid;
+    }
+    top.splice(lo, 0, item);
+    if (top.length > k) top.shift();
+  }
+
+  function corr(x, y) {
+    const n = Math.min(x.length, y.length);
+    if (n < 3) return 0;
+    let sx = 0, sy = 0, sxx = 0, syy = 0, sxy = 0;
+    for (let i = 0; i < n; i++) {
+      const a = x[i];
+      const b = y[i];
+      sx += a;
+      sy += b;
+      sxx += a * a;
+      syy += b * b;
+      sxy += a * b;
+    }
+    const mx = sx / n;
+    const my = sy / n;
+    const vx = sxx / n - mx * mx;
+    const vy = syy / n - my * my;
+    const cov = sxy / n - mx * my;
+    const denom = Math.sqrt(Math.max(0, vx)) * Math.sqrt(Math.max(0, vy));
+    if (denom <= 0) return 0;
+    return cov / denom;
+  }
+
+  for (let i = 0; i < sampled.length; i++) {
+    for (let j = i + 1; j < sampled.length; j++) {
+      const r = corr(sampled[i].arr, sampled[j].arr);
+      if (top.length < k || Math.abs(r) > Math.abs(top[0].r)) {
+        insert({ a: sampled[i].uuid, b: sampled[j].uuid, r });
+      }
+    }
+  }
+
+  top.sort((x, y) => Math.abs(y.r) - Math.abs(x.r));
+  return top;
+}
+
+// ============================================================================
+// Issues tab UI
+// ============================================================================
+
+function renderIssuesPanel(currentUuid, neuronType) {
+  if (!el.neuronTabPanelIssues) return;
+  if (!SNAPSHOT) {
+    el.neuronTabPanelIssues.innerHTML = "";
+    return;
+  }
+
+  const isInput = currentUuid?.startsWith?.("input-") || neuronType === "input";
+
+  const dead = DIAG_DEADZONES.get(currentUuid);
+  const nonFinite = DIAG_NONFINITE.get(currentUuid);
+  const tail = DIAG_ERROR_TAIL.get(currentUuid);
+
+  const pieces = [];
+
+  pieces.push(`<div class="panelSectionTitle">Current neuron</div>`);
+  pieces.push(`<div class="issueList">`);
+
+  // Saturation & dead zones.
+  if (!isInput && dead) {
+    const dd = [];
+    if (dead.fracClamped != null) {
+      dd.push(`Clamp %: ${formatSig(dead.fracClamped * 100, 4)}%`);
+    }
+    if (dead.fracAtZero != null) {
+      dd.push(`Dead zone %: ${formatSig(dead.fracAtZero * 100, 4)}%`);
+    }
+    if (dead.nonFiniteCount > 0) {
+      dd.push(`Non-finite pre-acts: ${dead.nonFiniteCount}`);
+    }
+    if (dd.length > 0) {
+      pieces.push(`
+        <div class="issueRow">
+          <div class="issueRowTitle">Saturation & dead zones</div>
+          <div class="synapseStats">${
+        dd.map((x) => `<span class="stat">${escapeHtml(x)}</span>`).join("")
+      }</div>
+        </div>
+      `);
+    }
+  }
+
+  // Non-finite activations / errors.
+  if (nonFinite) {
+    const dd = [];
+    if (nonFinite.activation?.count > 0) {
+      dd.push(
+        `Non-finite activations: ${nonFinite.activation.count} (first obs_index=${nonFinite.activation.firstObsIndex})`,
+      );
+    }
+    if (nonFinite.value?.count > 0) {
+      dd.push(
+        `Non-finite values: ${nonFinite.value.count} (first obs_index=${nonFinite.value.firstObsIndex})`,
+      );
+    }
+    if (nonFinite.errors?.count > 0) {
+      dd.push(
+        `Non-finite errors: ${nonFinite.errors.count} (first obs_index=${nonFinite.errors.firstObsIndex})`,
+      );
+    }
+    pieces.push(`
+      <div class="issueRow">
+        <div class="issueRowTitle">Exploding / non-finite</div>
+        <div class="synapseStats">${
+      dd.length
+        ? dd.map((x) => `<span class="stat error">${escapeHtml(x)}</span>`)
+          .join("")
+        : `<span class="stat">No non-finite values detected</span>`
+    }</div>
+      </div>
+    `);
+  } else {
+    pieces.push(`
+      <div class="issueRow">
+        <div class="issueRowTitle">Exploding / non-finite</div>
+        <div class="synapseStats"><span class="stat">No non-finite values detected</span></div>
+      </div>
+    `);
+  }
+
+  // Error concentration.
+  if (!isInput && tail) {
+    const top = tail.topK?.slice?.(0, 4) ?? [];
+    const dd = [];
+    if (top.length > 0) {
+      dd.push(
+        `Top obs share: ${formatSig((top[0]?.shareOfTotal ?? 0) * 100, 4)}%`,
+      );
+      dd.push(`Top-k share: ${formatSig((tail.topKShare ?? 0) * 100, 4)}%`);
+      dd.push(`Top obs_index: ${top.map((t) => t.obsIndex).join(", ")}`);
+    }
+    pieces.push(`
+      <div class="issueRow">
+        <div class="issueRowTitle">Error concentration</div>
+        <div class="synapseStats">${
+      dd.length
+        ? dd.map((x) => `<span class="stat">${escapeHtml(x)}</span>`).join("")
+        : `<span class="stat">No per-observation error data</span>`
+    }</div>
+      </div>
+    `);
+  }
+
+  pieces.push(`</div>`);
+
+  // Global lists (quickly actionable).
+  pieces.push(`<div class="panelSectionTitle">Flagged neurons</div>`);
+
+  const nonFiniteUuids = Array.from(DIAG_NONFINITE.entries())
+    .sort((a, b) => (b[1]?.total ?? 0) - (a[1]?.total ?? 0))
+    .slice(0, 10);
+
+  const clampedUuids = Array.from(DIAG_DEADZONES.entries())
+    .filter(([uuid, d]) => uuid && d && d.fracClamped != null)
+    .sort((a, b) => (b[1].fracClamped ?? 0) - (a[1].fracClamped ?? 0))
+    .slice(0, 10);
+
+  const deadReluUuids = Array.from(DIAG_DEADZONES.entries())
+    .filter(([uuid, d]) => uuid && d && d.fracAtZero != null)
+    .sort((a, b) => (b[1].fracAtZero ?? 0) - (a[1].fracAtZero ?? 0))
+    .slice(0, 10);
+
+  const heavyTail = Array.from(DIAG_ERROR_TAIL.entries())
+    .sort((a, b) =>
+      (b[1]?.topK?.[0]?.shareOfTotal ?? 0) -
+      (a[1]?.topK?.[0]?.shareOfTotal ?? 0)
+    )
+    .slice(0, 10);
+
+  function renderJumpList(title, rows, renderStats) {
+    if (!rows || rows.length === 0) return "";
+    const html = rows.map(([uuid, data]) => {
+      const stats = renderStats(data);
+      return `
+        <div class="issueRow" data-jump-uuid="${escapeHtml(uuid)}">
+          <div class="issueRowTitle">${
+        escapeHtml(truncateNeuronName(uuid))
+      }</div>
+          <div class="synapseStats">${stats}</div>
+        </div>
+      `;
+    }).join("");
+    return `<div class="panelSectionTitle">${
+      escapeHtml(title)
+    }</div><div class="issueList">${html}</div>`;
+  }
+
+  pieces.push(renderJumpList(
+    "Non-finite (top 10)",
+    nonFiniteUuids,
+    (d) =>
+      `<span class="stat error">count: ${
+        escapeHtml(String(d.total ?? 0))
+      }</span>` +
+      (d.errors?.firstObsIndex != null
+        ? `<span class="stat">first obs_index: ${
+          escapeHtml(String(d.errors.firstObsIndex))
+        }</span>`
+        : ""),
+  ));
+
+  pieces.push(renderJumpList(
+    "Clamp % (top 10)",
+    clampedUuids,
+    (d) =>
+      `<span class="stat">clamp: ${
+        escapeHtml(formatSig((d.fracClamped ?? 0) * 100, 4))
+      }%</span>`,
+  ));
+
+  pieces.push(renderJumpList(
+    "Dead zone % (top 10)",
+    deadReluUuids,
+    (d) =>
+      `<span class="stat">dead: ${
+        escapeHtml(formatSig((d.fracAtZero ?? 0) * 100, 4))
+      }%</span>`,
+  ));
+
+  pieces.push(renderJumpList(
+    "Error heavy-tail (top 10)",
+    heavyTail,
+    (d) =>
+      `<span class="stat">top1: ${
+        escapeHtml(formatSig((d.topK?.[0]?.shareOfTotal ?? 0) * 100, 4))
+      }%</span>` +
+      `<span class="stat">top-k: ${
+        escapeHtml(formatSig((d.topKShare ?? 0) * 100, 4))
+      }%</span>`,
+  ));
+
+  // Input issues (redundancy).
+  pieces.push(`<div class="panelSectionTitle">Inputs</div>`);
+  const inputBits = [];
+  if (DIAG_INPUTS?.constantInputs?.length) {
+    inputBits.push(`<div class="issueRowTitle">Near-constant inputs</div>`);
+    inputBits.push(
+      `<div class="synapseStats">${
+        DIAG_INPUTS.constantInputs.slice(0, 10).map((x) =>
+          `<span class="stat">${escapeHtml(x.uuid)} std≈${
+            escapeHtml(formatSig(x.std, 3))
+          }</span>`
+        ).join("")
+      }</div>`,
+    );
+  }
+  if (DIAG_INPUTS?.correlatedPairs?.length) {
+    inputBits.push(`<div class="issueRowTitle">Highly correlated pairs</div>`);
+    inputBits.push(
+      `<div class="synapseStats">${
+        DIAG_INPUTS.correlatedPairs.slice(0, 8).map((p) =>
+          `<span class="stat">${escapeHtml(p.a)} ↔ ${escapeHtml(p.b)} r=${
+            escapeHtml(formatSig(p.r, 4))
+          }</span>`
+        ).join("")
+      }</div>`,
+    );
+  }
+  if (DIAG_INPUTS?.candidateCoverage?.length) {
+    inputBits.push(`<div class="issueRowTitle">Candidate coverage</div>`);
+    inputBits.push(
+      `<div class="synapseStats">${
+        DIAG_INPUTS.candidateCoverage.slice(0, 10).map((c) =>
+          `<span class="stat">${escapeHtml(c.uuid)} candidates=${
+            escapeHtml(String(c.count))
+          } (+${escapeHtml(String(c.helpful))}/-${
+            escapeHtml(String(c.harmful))
+          })</span>`
+        ).join("")
+      }</div>`,
+    );
+  }
+  pieces.push(
+    `<div class="issueRow">${
+      inputBits.length
+        ? inputBits.join("")
+        : `<div class="synapseStats"><span class="stat">No input redundancy data</span></div>`
+    }</div>`,
+  );
+
+  el.neuronTabPanelIssues.innerHTML = pieces.join("");
+
+  el.neuronTabPanelIssues.onclick = (ev) => {
+    const target = ev.target;
+    if (!(target instanceof HTMLElement)) return;
+    const row = target.closest("[data-jump-uuid]");
+    if (!row) return;
+    const uuid = row.getAttribute("data-jump-uuid");
+    if (uuid) navigateTo(uuid);
+  };
+}
+
+// ============================================================================
+// Candidates tab UI
+// ============================================================================
+
+function renderCandidatesPanel(currentUuid) {
+  if (!el.neuronTabPanelCandidates) return;
+  if (!SNAPSHOT) {
+    el.neuronTabPanelCandidates.innerHTML = "";
+    return;
+  }
+
+  const relevant = (DISCOVERY_CANDIDATES ?? []).filter((c) =>
+    c?.fromUuid === currentUuid || c?.toUuid === currentUuid
+  );
+
+  const selected =
+    (DISCOVERY_CANDIDATES ?? []).find((c) => c.key === selectedCandidateKey) ??
+      null;
+
+  const list = relevant.length ? relevant : (DISCOVERY_CANDIDATES ?? []);
+  const listTitle = relevant.length
+    ? "Candidates involving this neuron"
+    : "Candidates (snapshot)";
+
+  const rows = list.map((c) => {
+    const isSelected = c.key === selectedCandidateKey;
+    const title = `${c.type || "candidate"}: ${
+      truncateUuid(c.fromUuid ?? "?")
+    } → ${truncateUuid(c.toUuid ?? "?")}`;
+    const stats = [];
+    if (c.expectedScoreGain != null) {
+      stats.push(
+        `<span class="stat ${
+          c.expectedScoreGain >= 0 ? "positive" : "negative"
+        }" title="Expected score gain">Δscore: ${
+          escapeHtml(formatSig(c.expectedScoreGain, 4))
+        }</span>`,
+      );
+    }
+    if (c.expectedImpact != null) {
+      stats.push(
+        `<span class="stat" title="Expected impact">impact: ${
+          escapeHtml(formatSig(c.expectedImpact, 4))
+        }</span>`,
+      );
+    }
+    return `
+      <div class="candidateRow ${
+      isSelected ? "isSelected" : ""
+    }" data-cand-key="${escapeHtml(c.key)}">
+        <div class="candidateRowTitle">${escapeHtml(title)}</div>
+        <div class="synapseStats">${stats.join("")}</div>
+      </div>
+    `;
+  }).join("");
+
+  const detail = selected
+    ? renderSplitSynapseCandidateDetail(selected)
+    : `<div class="emptyState">Select a candidate to inspect details.</div>`;
+
+  el.neuronTabPanelCandidates.innerHTML = `
+    <div class="panelSectionTitle">${escapeHtml(listTitle)}</div>
+    <div class="candidateList">${
+    rows ||
+    `<div class="emptyState">No discovery candidates in this snapshot.</div>`
+  }</div>
+    <div class="panelSectionTitle">Candidate details</div>
+    ${detail}
+  `;
+
+  el.neuronTabPanelCandidates.onclick = (ev) => {
+    const target = ev.target;
+    if (!(target instanceof HTMLElement)) return;
+    const row = target.closest("[data-cand-key]");
+    if (!row) return;
+    const key = row.getAttribute("data-cand-key");
+    if (!key) return;
+    selectedCandidateKey = key;
+    renderCandidatesPanel(currentUuid);
+    renderSynapseList(currentUuid);
+  };
+}
+
+function renderSplitSynapseCandidateDetail(c) {
+  const isSplit =
+    String(c.type ?? "").toLowerCase() === "split_synapse_insert_neuron";
+
+  const from = c.fromUuid ?? "?";
+  const to = c.toUuid ?? "?";
+
+  // Small before/after diff summary.
+  const diff = `
+    <dl class="candidateDiffGrid">
+      <dt>Synapse count Δ</dt><dd>+1 (−1 +2)</dd>
+      <dt>Neuron count Δ</dt><dd>+1</dd>
+      <dt>Removed synapse</dt><dd>${escapeHtml(`${from} → ${to}`)}</dd>
+    </dl>
+  `;
+
+  const svg = renderCandidateDiagramSvg(c);
+
+  const details = [];
+  details.push(
+    `<div class="issueRowTitle">${
+      escapeHtml(
+        isSplit ? "split_synapse_insert_neuron" : (c.type || "candidate"),
+      )
+    }</div>`,
+  );
+  details.push(`<div class="synapseStats">`);
+  details.push(
+    `<span class="stat" title="from/to UUIDs">${
+      escapeHtml(`${truncateUuid(from)} → ${truncateUuid(to)}`)
+    }</span>`,
+  );
+  if (c.fromIndex != null || c.toIndex != null) {
+    details.push(
+      `<span class="stat" title="from/to indices">idx: ${
+        escapeHtml(String(c.fromIndex ?? "?"))
+      } → ${escapeHtml(String(c.toIndex ?? "?"))}</span>`,
+    );
+  }
+  if (c.oldWeight != null) {
+    details.push(
+      `<span class="stat" title="Old weight">old w: ${
+        escapeHtml(formatSig(c.oldWeight, 6))
+      }</span>`,
+    );
+  }
+  if (c.newWeightA != null || c.newWeightB != null) {
+    details.push(
+      `<span class="stat" title="New weights">new w: ${
+        escapeHtml(formatSig(c.newWeightA ?? 0, 6))
+      }, ${escapeHtml(formatSig(c.newWeightB ?? 0, 6))}</span>`,
+    );
+  }
+  if (c.newNeuronSquash) {
+    details.push(
+      `<span class="stat" title="New neuron squash">squash: ${
+        escapeHtml(c.newNeuronSquash)
+      }</span>`,
+    );
+  }
+  if (c.newNeuronBias != null) {
+    details.push(
+      `<span class="stat" title="New neuron bias">bias: ${
+        escapeHtml(formatSig(c.newNeuronBias, 6))
+      }</span>`,
+    );
+  }
+  if (c.expectedScoreGain != null) {
+    details.push(
+      `<span class="stat ${
+        c.expectedScoreGain >= 0 ? "positive" : "negative"
+      }" title="Expected score gain">Δscore: ${
+        escapeHtml(formatSig(c.expectedScoreGain, 6))
+      }</span>`,
+    );
+  }
+  if (c.expectedImpact != null) {
+    details.push(
+      `<span class="stat" title="Expected impact">impact: ${
+        escapeHtml(formatSig(c.expectedImpact, 6))
+      }</span>`,
+    );
+  }
+  details.push(`</div>`);
+
+  if (c.comment) {
+    details.push(
+      `<div class="impactBreakdownNote">${escapeHtml(c.comment)}</div>`,
+    );
+  }
+
+  const rawJson = escapeHtml(JSON.stringify(c.raw ?? {}, null, 2));
+
+  return `
+    <div class="issueRow">
+      ${details.join("")}
+      ${svg}
+      ${diff}
+      <details class="pathItem" style="margin-top: 10px;">
+        <summary>Raw candidate JSON</summary>
+        <pre class="pathEquation" style="white-space: pre-wrap;">${rawJson}</pre>
+      </details>
+    </div>
+  `;
+}
+
+function renderCandidateDiagramSvg(c) {
+  const from = truncateNeuronName(c.fromUuid ?? "?");
+  const to = truncateNeuronName(c.toUuid ?? "?");
+  const midSquash = c.newNeuronSquash ?? "IDENTITY";
+  const midBias = c.newNeuronBias != null ? formatSig(c.newNeuronBias, 4) : "0";
+  const w1 = c.newWeightA != null ? formatSig(c.newWeightA, 4) : "?";
+  const w2 = c.newWeightB != null ? formatSig(c.newWeightB, 4) : "?";
+  const oldW = c.oldWeight != null ? formatSig(c.oldWeight, 4) : "?";
+
+  // Simple inline SVG: from → ghost → to, with old edge highlighted.
+  return `
+    <svg class="candidateDiagram" viewBox="0 0 360 120" aria-label="Candidate diagram">
+      <defs>
+        <marker id="arrowOld" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+          <path d="M0,0 L8,3 L0,6 Z" fill="var(--warning)"></path>
+        </marker>
+        <marker id="arrowNew" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+          <path d="M0,0 L8,3 L0,6 Z" fill="var(--accent)"></path>
+        </marker>
+      </defs>
+
+      <!-- Old edge (to be replaced) -->
+      <line x1="60" y1="60" x2="300" y2="60" class="candidateDiagramOldEdge" marker-end="url(#arrowOld)"></line>
+      <text x="180" y="48" text-anchor="middle" class="candidateDiagramText">old w=${
+    escapeHtml(oldW)
+  }</text>
+
+      <!-- New edges (proposed) -->
+      <line x1="60" y1="80" x2="170" y2="80" class="candidateDiagramNewEdge" marker-end="url(#arrowNew)"></line>
+      <line x1="190" y1="80" x2="300" y2="80" class="candidateDiagramNewEdge" marker-end="url(#arrowNew)"></line>
+      <text x="115" y="100" text-anchor="middle" class="candidateDiagramText">w1=${
+    escapeHtml(w1)
+  }</text>
+      <text x="245" y="100" text-anchor="middle" class="candidateDiagramText">w2=${
+    escapeHtml(w2)
+  }</text>
+
+      <!-- Nodes -->
+      <circle cx="50" cy="60" r="18" class="candidateDiagramNode"></circle>
+      <text x="50" y="65" text-anchor="middle" class="candidateDiagramText">from</text>
+
+      <rect x="160" y="18" width="40" height="40" rx="10" class="candidateDiagramGhost"></rect>
+      <text x="180" y="40" text-anchor="middle" class="candidateDiagramText">ghost</text>
+      <text x="180" y="18" text-anchor="middle" class="candidateDiagramText"></text>
+
+      <circle cx="310" cy="60" r="18" class="candidateDiagramNode"></circle>
+      <text x="310" y="65" text-anchor="middle" class="candidateDiagramText">to</text>
+
+      <text x="50" y="18" text-anchor="middle" class="candidateDiagramText">${
+    escapeHtml(from)
+  }</text>
+      <text x="310" y="18" text-anchor="middle" class="candidateDiagramText">${
+    escapeHtml(to)
+  }</text>
+
+      <text x="180" y="70" text-anchor="middle" class="candidateDiagramText">squash=${
+    escapeHtml(midSquash)
+  } bias=${escapeHtml(midBias)}</text>
+    </svg>
+  `;
 }
 
 // ============================================================================

--- a/docs/app.js
+++ b/docs/app.js
@@ -1429,6 +1429,15 @@ function initTouchTooltips() {
       const target = findTooltipTarget(e.target);
       if (!target) return;
 
+      // If a long-press just opened a tooltip, iOS will often fire a follow-up
+      // click on release. During the suppression window, do not toggle/close the
+      // tooltip; just swallow the click to prevent accidental actions.
+      if (Date.now() < suppressClickUntil) {
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
+
       // Toggle: tapping the same target closes the tooltip.
       if (
         shownForTarget && target === shownForTarget &&
@@ -1443,22 +1452,6 @@ function initTouchTooltips() {
       // Don't let the click bubble and trigger row navigation underneath.
       e.preventDefault();
       e.stopPropagation();
-    },
-    { capture: true },
-  );
-
-  // If we just showed a tooltip, suppress the follow-up click so we don't
-  // accidentally trigger navigation (e.g. tapping a stat inside a synapse row).
-  document.addEventListener(
-    "click",
-    (e) => {
-      if (Date.now() > suppressClickUntil) return;
-      const target = findTooltipTarget(e.target);
-      if (!target) return;
-      if (shownForTarget && target === shownForTarget) {
-        e.preventDefault();
-        e.stopPropagation();
-      }
     },
     { capture: true },
   );

--- a/docs/app.js
+++ b/docs/app.js
@@ -1474,6 +1474,10 @@ function initTouchTooltips() {
     (e) => {
       if (!tooltipEl?.classList.contains("isOpen")) return;
       if (tooltipEl.contains(e.target)) return;
+      // If the click was on a known tooltip target, let the tap-to-toggle handler
+      // manage it. Both listeners run on `document` in the capture phase, so we
+      // must explicitly avoid immediately closing a tooltip we just opened.
+      if (findTooltipTarget(e.target)) return;
       hideTouchTooltip();
     },
     { capture: true },

--- a/docs/app.js
+++ b/docs/app.js
@@ -1388,7 +1388,6 @@ function initTouchTooltips() {
     "touchstart",
     (e) => {
       if (pressTimer) clearTimeout(pressTimer);
-      shownForTarget = null;
 
       const target = findTooltipTarget(e.target);
       if (!target) return;
@@ -1462,6 +1461,9 @@ function initTouchTooltips() {
     (e) => {
       if (!tooltipEl?.classList.contains("isOpen")) return;
       if (tooltipEl.contains(e.target)) return;
+      // If the touch is on a known tooltip target, let the tap-to-toggle handler
+      // manage it. Otherwise, we'd close on touchstart then re-open on click.
+      if (findTooltipTarget(e.target)) return;
       hideTouchTooltip();
     },
     { passive: true },

--- a/docs/impact_diagnostics.js
+++ b/docs/impact_diagnostics.js
@@ -170,6 +170,128 @@ export function summariseSeriesStats(arr, options = {}) {
 }
 
 /**
+ * Summarise pre-activation dead zones / clamp behaviour for common squashes.
+ *
+ * This is used by the Issues tab to quickly spot:
+ * - Hard clamps (HARD_TANH / CLIPPED / RELU6) where large fractions of samples
+ *   are in the flat/clamped region.
+ * - Dead ReLUs (RELU / LeakyReLU) where many samples are at/below 0.
+ *
+ * Notes:
+ * - We intentionally keep this conservative and cheap (single pass).
+ * - We treat non-finite values as an issue and report the first offending index.
+ *
+ * @param {string} squash
+ * @param {number[]} preActs
+ * @returns {{
+ *   n: number,
+ *   fracClamped: number | null,
+ *   fracAtZero: number | null,
+ *   nonFiniteCount: number,
+ *   firstNonFiniteIndex: number | null,
+ * }}
+ */
+export function summariseDeadZoneStats(squash, preActs) {
+  const s = String(squash ?? "IDENTITY").toUpperCase();
+  const arr = Array.isArray(preActs) ? preActs : [];
+
+  let n = 0;
+  let clamped = 0;
+  let atZero = 0;
+  let nonFiniteCount = 0;
+  let firstNonFiniteIndex = null;
+
+  for (let i = 0; i < arr.length; i++) {
+    const v = arr[i];
+    if (typeof v !== "number" || !isFinite(v)) {
+      nonFiniteCount += 1;
+      if (firstNonFiniteIndex == null) firstNonFiniteIndex = i;
+      continue;
+    }
+    n += 1;
+
+    if (s === "HARD_TANH" || s === "CLIPPED") {
+      if (v <= -1 || v >= 1) clamped += 1;
+    } else if (s === "RELU6") {
+      if (v <= 0 || v >= 6) clamped += 1;
+    }
+
+    if (s === "RELU" || s === "LEAKYRELU") {
+      // For RELU, activation is 0 when pre-activation <= 0.
+      // For LeakyReLU, the "dead-ish" region is also pre-activation <= 0.
+      if (v <= 0) atZero += 1;
+    }
+  }
+
+  const fracClamped = (s === "HARD_TANH" || s === "CLIPPED" || s === "RELU6")
+    ? (n > 0 ? clamped / n : 0)
+    : null;
+  const fracAtZero = (s === "RELU" || s === "LEAKYRELU")
+    ? (n > 0 ? atZero / n : 0)
+    : null;
+
+  return { n, fracClamped, fracAtZero, nonFiniteCount, firstNonFiniteIndex };
+}
+
+/**
+ * Summarise how concentrated a non-negative series is (e.g., per-observation
+ * squared error contributions).
+ *
+ * This helps catch heavy-tail failure modes where a handful of observations
+ * dominate MSE, masking broader model issues.
+ *
+ * @param {number[]} contributions
+ * @param {{ topK?: number }} [options]
+ * @returns {{
+ *   n: number,
+ *   total: number,
+ *   topK: { index: number, value: number, shareOfTotal: number }[],
+ *   topKShare: number,
+ * }}
+ */
+export function summariseErrorConcentration(contributions, options = {}) {
+  const arr = Array.isArray(contributions) ? contributions : [];
+  const k = Math.max(1, Math.floor(options.topK ?? 8));
+
+  let total = 0;
+  /** @type {{ index: number, value: number }[]} */
+  const top = [];
+
+  function insertTop(item) {
+    // Keep `top` sorted ascending by value (smallest first).
+    let lo = 0;
+    let hi = top.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (top[mid].value <= item.value) lo = mid + 1;
+      else hi = mid;
+    }
+    top.splice(lo, 0, item);
+    if (top.length > k) top.shift();
+  }
+
+  for (let i = 0; i < arr.length; i++) {
+    const v = arr[i];
+    if (typeof v !== "number" || !isFinite(v) || v < 0) continue;
+    total += v;
+    if (top.length < k || v > top[0].value) insertTop({ index: i, value: v });
+  }
+
+  // Sort descending for presentation.
+  top.sort((a, b) => b.value - a.value);
+
+  const denom = total > 0 ? total : 1;
+  const topK = top.map((t) => ({
+    index: t.index,
+    value: t.value,
+    shareOfTotal: t.value / denom,
+  }));
+  const topKShare = topK.reduce((acc, t) => acc + t.shareOfTotal, 0);
+
+  return { n: arr.length, total, topK, topKShare };
+}
+
+/**
  * Basic squashes + derivatives. Where we don't know the precise NEAT-AI
  * behaviour, we keep it conservative and mark as non-smooth/unknown.
  *

--- a/docs/impact_diagnostics.js
+++ b/docs/impact_diagnostics.js
@@ -53,6 +53,123 @@ function summariseDerivative(arr) {
 }
 
 /**
+ * Summarise a numeric series (e.g., pre-activations) so we can spot scale issues.
+ *
+ * Terminology:
+ * - "Pre-activation" (aka "net input") is the value before the squash/activation:
+ *   \(z = b + \sum_i w_i x_i\)
+ *
+ * Notes:
+ * - Percentiles are approximate when the series is long; we take an evenly spaced
+ *   sample to keep this fast in the browser.
+ *
+ * @param {number[]} arr
+ * @param {{ sampleSize?: number }} [options]
+ * @returns {{
+ *   n: number,
+ *   mean: number,
+ *   std: number,
+ *   min: number,
+ *   max: number,
+ *   meanAbs: number,
+ *   maxAbs: number,
+ *   p01: number,
+ *   p50: number,
+ *   p99: number,
+ * }}
+ */
+export function summariseSeriesStats(arr, options = {}) {
+  const sampleSize = Math.max(8, Math.floor(options.sampleSize ?? 512));
+  if (!Array.isArray(arr) || arr.length === 0) {
+    return {
+      n: 0,
+      mean: 0,
+      std: 0,
+      min: 0,
+      max: 0,
+      meanAbs: 0,
+      maxAbs: 0,
+      p01: 0,
+      p50: 0,
+      p99: 0,
+    };
+  }
+
+  // Welford online mean/variance + min/max.
+  let n = 0;
+  let mean = 0;
+  let m2 = 0;
+  let min = Infinity;
+  let max = -Infinity;
+  let sumAbs = 0;
+  let maxAbs = 0;
+
+  for (const v of arr) {
+    if (typeof v !== "number" || !isFinite(v)) continue;
+    n += 1;
+    const delta = v - mean;
+    mean += delta / n;
+    const delta2 = v - mean;
+    m2 += delta * delta2;
+    if (v < min) min = v;
+    if (v > max) max = v;
+    const av = Math.abs(v);
+    sumAbs += av;
+    if (av > maxAbs) maxAbs = av;
+  }
+
+  const variance = n > 1 ? (m2 / (n - 1)) : 0;
+  const std = Math.sqrt(Math.max(0, variance));
+  const meanAbs = n > 0 ? (sumAbs / n) : 0;
+
+  // Percentiles (approx): evenly spaced downsample then sort.
+  const take = Math.min(sampleSize, arr.length);
+  /** @type {number[]} */
+  const sample = [];
+  if (take === arr.length) {
+    for (const v of arr) {
+      if (typeof v === "number" && isFinite(v)) sample.push(v);
+    }
+  } else {
+    const step = arr.length / take;
+    for (let i = 0; i < take; i++) {
+      const idx = Math.min(arr.length - 1, Math.floor(i * step));
+      const v = arr[idx];
+      if (typeof v === "number" && isFinite(v)) sample.push(v);
+    }
+  }
+  sample.sort((a, b) => a - b);
+
+  function q(p) {
+    if (sample.length === 0) return 0;
+    const t = Math.max(0, Math.min(1, p));
+    const pos = (sample.length - 1) * t;
+    const lo = Math.floor(pos);
+    const hi = Math.ceil(pos);
+    if (lo === hi) return sample[lo];
+    const w = pos - lo;
+    return sample[lo] * (1 - w) + sample[hi] * w;
+  }
+
+  const p01 = q(0.01);
+  const p50 = q(0.5);
+  const p99 = q(0.99);
+
+  return {
+    n,
+    mean,
+    std,
+    min: isFinite(min) ? min : 0,
+    max: isFinite(max) ? max : 0,
+    meanAbs,
+    maxAbs,
+    p01,
+    p50,
+    p99,
+  };
+}
+
+/**
  * Basic squashes + derivatives. Where we don't know the precise NEAT-AI
  * behaviour, we keep it conservative and mark as non-smooth/unknown.
  *

--- a/docs/index.html
+++ b/docs/index.html
@@ -84,8 +84,55 @@
         <section class="currentNeuron">
           <h2 id="currentNeuronTitle">output-0</h2>
           <dl id="neuronProps" class="propList"></dl>
-          <div id="impactBreakdown" class="impactBreakdown"></div>
-          <div id="impactDiagnosticsPanel" class="impactBreakdown"></div>
+
+          <div class="tabRow" role="tablist" aria-label="Neuron panels">
+            <button
+              id="neuronTabDetails"
+              class="tabBtn isActive"
+              type="button"
+              role="tab"
+              aria-selected="true"
+              aria-controls="neuronTabPanelDetails"
+            >
+              Details
+            </button>
+            <button
+              id="neuronTabIssues"
+              class="tabBtn"
+              type="button"
+              role="tab"
+              aria-selected="false"
+              aria-controls="neuronTabPanelIssues"
+            >
+              Issues
+            </button>
+            <button
+              id="neuronTabCandidates"
+              class="tabBtn"
+              type="button"
+              role="tab"
+              aria-selected="false"
+              aria-controls="neuronTabPanelCandidates"
+            >
+              Candidates
+            </button>
+          </div>
+
+          <div
+            id="neuronTabPanelDetails"
+            class="tabPanel isActive"
+            role="tabpanel"
+          >
+            <div id="impactBreakdown" class="impactBreakdown"></div>
+            <div id="impactDiagnosticsPanel" class="impactBreakdown"></div>
+          </div>
+          <div id="neuronTabPanelIssues" class="tabPanel" role="tabpanel"></div>
+          <div
+            id="neuronTabPanelCandidates"
+            class="tabPanel"
+            role="tabpanel"
+          >
+          </div>
         </section>
 
         <!-- Arrow -->

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -353,6 +353,131 @@ html, body {
   font-weight: 600;
 }
 
+/* Tabs (Details / Issues / Candidates) */
+.tabRow {
+  display: flex;
+  gap: 8px;
+  margin-top: 14px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+
+.tabBtn {
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--buttonSecondaryBg);
+  color: var(--text);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.tabBtn.isActive {
+  border-color: var(--accent);
+  background: rgba(96, 165, 250, 0.18);
+}
+
+.tabPanel {
+  display: none;
+}
+
+.tabPanel.isActive {
+  display: block;
+}
+
+/* Candidate/issue panels */
+.panelSectionTitle {
+  margin-top: 14px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.issueList, .candidateList {
+  margin-top: 10px;
+  display: grid;
+  gap: 8px;
+}
+
+.issueRow, .candidateRow {
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surfaceSofter);
+  cursor: pointer;
+}
+
+.issueRow:hover, .candidateRow:hover {
+  background: var(--panelHover);
+}
+
+.issueRowTitle, .candidateRowTitle {
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  margin-bottom: 6px;
+  color: var(--text);
+  word-break: break-word;
+}
+
+.candidateDiagram {
+  width: 100%;
+  max-width: 320px;
+  margin-top: 8px;
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  background: rgba(96, 165, 250, 0.06);
+}
+
+.candidateDiagramText {
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
+  fill: var(--text);
+}
+
+.candidateDiagramGhost {
+  stroke: var(--warning);
+  stroke-dasharray: 5 4;
+  fill: transparent;
+}
+
+.candidateDiagramOldEdge {
+  stroke: var(--warning);
+  stroke-width: 3;
+  opacity: 0.7;
+}
+
+.candidateDiagramNewEdge {
+  stroke: var(--accent);
+  stroke-width: 2.5;
+  stroke-dasharray: 6 5;
+  opacity: 0.95;
+}
+
+.candidateDiagramNode {
+  fill: var(--panel);
+  stroke: var(--border);
+  stroke-width: 1.5;
+}
+
+.candidateDiffGrid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 10px;
+  margin-top: 10px;
+  font-size: 12px;
+}
+
+.candidateDiffGrid dt {
+  color: var(--muted);
+}
+
+.candidateDiffGrid dd {
+  font-family: ui-monospace, monospace;
+  word-break: break-word;
+}
+
 /* Impact breakdown to outputs (heuristic attribution). */
 .impactBreakdown {
   margin-top: 16px;
@@ -680,6 +805,15 @@ html, body {
 .synapseRow.inTrace {
   border-color: var(--trace);
   background: rgba(251, 191, 36, 0.08);
+}
+
+.synapseRow.candidateReplaceEdge {
+  border-color: var(--warning);
+  background: rgba(251, 146, 60, 0.12);
+}
+
+.synapseRow.candidateReplaceEdge:hover {
+  border-color: var(--warning);
 }
 
 .synapseFrom {

--- a/impact_diagnostics.js
+++ b/impact_diagnostics.js
@@ -170,6 +170,128 @@ export function summariseSeriesStats(arr, options = {}) {
 }
 
 /**
+ * Summarise pre-activation dead zones / clamp behaviour for common squashes.
+ *
+ * This is used by the Issues tab to quickly spot:
+ * - Hard clamps (HARD_TANH / CLIPPED / RELU6) where large fractions of samples
+ *   are in the flat/clamped region.
+ * - Dead ReLUs (RELU / LeakyReLU) where many samples are at/below 0.
+ *
+ * Notes:
+ * - We intentionally keep this conservative and cheap (single pass).
+ * - We treat non-finite values as an issue and report the first offending index.
+ *
+ * @param {string} squash
+ * @param {number[]} preActs
+ * @returns {{
+ *   n: number,
+ *   fracClamped: number | null,
+ *   fracAtZero: number | null,
+ *   nonFiniteCount: number,
+ *   firstNonFiniteIndex: number | null,
+ * }}
+ */
+export function summariseDeadZoneStats(squash, preActs) {
+  const s = String(squash ?? "IDENTITY").toUpperCase();
+  const arr = Array.isArray(preActs) ? preActs : [];
+
+  let n = 0;
+  let clamped = 0;
+  let atZero = 0;
+  let nonFiniteCount = 0;
+  let firstNonFiniteIndex = null;
+
+  for (let i = 0; i < arr.length; i++) {
+    const v = arr[i];
+    if (typeof v !== "number" || !isFinite(v)) {
+      nonFiniteCount += 1;
+      if (firstNonFiniteIndex == null) firstNonFiniteIndex = i;
+      continue;
+    }
+    n += 1;
+
+    if (s === "HARD_TANH" || s === "CLIPPED") {
+      if (v <= -1 || v >= 1) clamped += 1;
+    } else if (s === "RELU6") {
+      if (v <= 0 || v >= 6) clamped += 1;
+    }
+
+    if (s === "RELU" || s === "LEAKYRELU") {
+      // For RELU, activation is 0 when pre-activation <= 0.
+      // For LeakyReLU, the "dead-ish" region is also pre-activation <= 0.
+      if (v <= 0) atZero += 1;
+    }
+  }
+
+  const fracClamped = (s === "HARD_TANH" || s === "CLIPPED" || s === "RELU6")
+    ? (n > 0 ? clamped / n : 0)
+    : null;
+  const fracAtZero = (s === "RELU" || s === "LEAKYRELU")
+    ? (n > 0 ? atZero / n : 0)
+    : null;
+
+  return { n, fracClamped, fracAtZero, nonFiniteCount, firstNonFiniteIndex };
+}
+
+/**
+ * Summarise how concentrated a non-negative series is (e.g., per-observation
+ * squared error contributions).
+ *
+ * This helps catch heavy-tail failure modes where a handful of observations
+ * dominate MSE, masking broader model issues.
+ *
+ * @param {number[]} contributions
+ * @param {{ topK?: number }} [options]
+ * @returns {{
+ *   n: number,
+ *   total: number,
+ *   topK: { index: number, value: number, shareOfTotal: number }[],
+ *   topKShare: number,
+ * }}
+ */
+export function summariseErrorConcentration(contributions, options = {}) {
+  const arr = Array.isArray(contributions) ? contributions : [];
+  const k = Math.max(1, Math.floor(options.topK ?? 8));
+
+  let total = 0;
+  /** @type {{ index: number, value: number }[]} */
+  const top = [];
+
+  function insertTop(item) {
+    // Keep `top` sorted ascending by value (smallest first).
+    let lo = 0;
+    let hi = top.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (top[mid].value <= item.value) lo = mid + 1;
+      else hi = mid;
+    }
+    top.splice(lo, 0, item);
+    if (top.length > k) top.shift();
+  }
+
+  for (let i = 0; i < arr.length; i++) {
+    const v = arr[i];
+    if (typeof v !== "number" || !isFinite(v) || v < 0) continue;
+    total += v;
+    if (top.length < k || v > top[0].value) insertTop({ index: i, value: v });
+  }
+
+  // Sort descending for presentation.
+  top.sort((a, b) => b.value - a.value);
+
+  const denom = total > 0 ? total : 1;
+  const topK = top.map((t) => ({
+    index: t.index,
+    value: t.value,
+    shareOfTotal: t.value / denom,
+  }));
+  const topKShare = topK.reduce((acc, t) => acc + t.shareOfTotal, 0);
+
+  return { n: arr.length, total, topK, topKShare };
+}
+
+/**
  * Basic squashes + derivatives. Where we don't know the precise NEAT-AI
  * behaviour, we keep it conservative and mark as non-smooth/unknown.
  *

--- a/impact_diagnostics.js
+++ b/impact_diagnostics.js
@@ -53,6 +53,123 @@ function summariseDerivative(arr) {
 }
 
 /**
+ * Summarise a numeric series (e.g., pre-activations) so we can spot scale issues.
+ *
+ * Terminology:
+ * - "Pre-activation" (aka "net input") is the value before the squash/activation:
+ *   \(z = b + \sum_i w_i x_i\)
+ *
+ * Notes:
+ * - Percentiles are approximate when the series is long; we take an evenly spaced
+ *   sample to keep this fast in the browser.
+ *
+ * @param {number[]} arr
+ * @param {{ sampleSize?: number }} [options]
+ * @returns {{
+ *   n: number,
+ *   mean: number,
+ *   std: number,
+ *   min: number,
+ *   max: number,
+ *   meanAbs: number,
+ *   maxAbs: number,
+ *   p01: number,
+ *   p50: number,
+ *   p99: number,
+ * }}
+ */
+export function summariseSeriesStats(arr, options = {}) {
+  const sampleSize = Math.max(8, Math.floor(options.sampleSize ?? 512));
+  if (!Array.isArray(arr) || arr.length === 0) {
+    return {
+      n: 0,
+      mean: 0,
+      std: 0,
+      min: 0,
+      max: 0,
+      meanAbs: 0,
+      maxAbs: 0,
+      p01: 0,
+      p50: 0,
+      p99: 0,
+    };
+  }
+
+  // Welford online mean/variance + min/max.
+  let n = 0;
+  let mean = 0;
+  let m2 = 0;
+  let min = Infinity;
+  let max = -Infinity;
+  let sumAbs = 0;
+  let maxAbs = 0;
+
+  for (const v of arr) {
+    if (typeof v !== "number" || !isFinite(v)) continue;
+    n += 1;
+    const delta = v - mean;
+    mean += delta / n;
+    const delta2 = v - mean;
+    m2 += delta * delta2;
+    if (v < min) min = v;
+    if (v > max) max = v;
+    const av = Math.abs(v);
+    sumAbs += av;
+    if (av > maxAbs) maxAbs = av;
+  }
+
+  const variance = n > 1 ? (m2 / (n - 1)) : 0;
+  const std = Math.sqrt(Math.max(0, variance));
+  const meanAbs = n > 0 ? (sumAbs / n) : 0;
+
+  // Percentiles (approx): evenly spaced downsample then sort.
+  const take = Math.min(sampleSize, arr.length);
+  /** @type {number[]} */
+  const sample = [];
+  if (take === arr.length) {
+    for (const v of arr) {
+      if (typeof v === "number" && isFinite(v)) sample.push(v);
+    }
+  } else {
+    const step = arr.length / take;
+    for (let i = 0; i < take; i++) {
+      const idx = Math.min(arr.length - 1, Math.floor(i * step));
+      const v = arr[idx];
+      if (typeof v === "number" && isFinite(v)) sample.push(v);
+    }
+  }
+  sample.sort((a, b) => a - b);
+
+  function q(p) {
+    if (sample.length === 0) return 0;
+    const t = Math.max(0, Math.min(1, p));
+    const pos = (sample.length - 1) * t;
+    const lo = Math.floor(pos);
+    const hi = Math.ceil(pos);
+    if (lo === hi) return sample[lo];
+    const w = pos - lo;
+    return sample[lo] * (1 - w) + sample[hi] * w;
+  }
+
+  const p01 = q(0.01);
+  const p50 = q(0.5);
+  const p99 = q(0.99);
+
+  return {
+    n,
+    mean,
+    std,
+    min: isFinite(min) ? min : 0,
+    max: isFinite(max) ? max : 0,
+    meanAbs,
+    maxAbs,
+    p01,
+    p50,
+    p99,
+  };
+}
+
+/**
  * Basic squashes + derivatives. Where we don't know the precise NEAT-AI
  * behaviour, we keep it conservative and mark as non-smooth/unknown.
  *

--- a/tests/impact_diagnostics_test.ts
+++ b/tests/impact_diagnostics_test.ts
@@ -158,3 +158,44 @@ Deno.test("gradient proxy matches a simple 1-edge network", () => {
   assert(terms.length === 1);
   approx(terms[0].term ?? 0, 2);
 });
+
+Deno.test("summariseSeriesStats computes basic stats", async () => {
+  // Use a dynamic import here because some editor linters can lag behind JS
+  // named export discovery, even though Deno's runtime/type-checker is fine.
+  const mod = await import("../impact_diagnostics.js") as unknown as Record<
+    string,
+    unknown
+  >;
+  const summariseSeriesStats = mod.summariseSeriesStats as
+    | ((arr: number[], options?: { sampleSize?: number }) => {
+      n: number;
+      mean: number;
+      std: number;
+      min: number;
+      max: number;
+      meanAbs: number;
+      maxAbs: number;
+      p01: number;
+      p50: number;
+      p99: number;
+    })
+    | undefined;
+
+  assert(
+    typeof summariseSeriesStats === "function",
+    "Expected summariseSeriesStats to be a function export",
+  );
+
+  const s = summariseSeriesStats([-2, -1, 0, 1, 2], { sampleSize: 32 });
+  assert(s.n === 5);
+  approx(s.mean, 0, 1e-12);
+  approx(s.min, -2, 1e-12);
+  approx(s.max, 2, 1e-12);
+  approx(s.meanAbs, 1.2, 1e-12);
+  approx(s.maxAbs, 2, 1e-12);
+
+  // Percentiles are exact here because we sample the full array.
+  approx(s.p50, 0, 1e-12);
+  assert(s.p99 > 1.5, "Expected p99 to be near the upper end");
+  assert(s.p01 < -1.5, "Expected p01 to be near the lower end");
+});

--- a/tests/impact_diagnostics_test.ts
+++ b/tests/impact_diagnostics_test.ts
@@ -199,3 +199,77 @@ Deno.test("summariseSeriesStats computes basic stats", async () => {
   assert(s.p99 > 1.5, "Expected p99 to be near the upper end");
   assert(s.p01 < -1.5, "Expected p01 to be near the lower end");
 });
+
+Deno.test("summariseDeadZoneStats detects clamp and dead ReLU rates", async () => {
+  // Use dynamic import here because some editor linters can lag behind JS
+  // named export discovery, even though Deno's runtime/type-checker is fine.
+  // (Keeps `deno lint` happy in this repo.)
+  const mod = (await import("../impact_diagnostics.js")) as unknown as Record<
+    string,
+    unknown
+  >;
+  const summariseDeadZoneStats = mod.summariseDeadZoneStats as
+    | ((squash: string, preActs: number[]) => {
+      n: number;
+      fracClamped: number | null;
+      fracAtZero: number | null;
+      nonFiniteCount: number;
+      firstNonFiniteIndex: number | null;
+    })
+    | undefined;
+
+  assert(
+    typeof summariseDeadZoneStats === "function",
+    "Expected summariseDeadZoneStats to be a function export",
+  );
+
+  // HARD_TANH clamps outside [-1, 1].
+  const hard = summariseDeadZoneStats("HARD_TANH", [
+    -2,
+    -1,
+    -0.5,
+    0,
+    0.2,
+    1,
+    2,
+  ]);
+  assert(hard.n === 7);
+  // clamped: -2, -1, 1, 2 => 4/7
+  approx(hard.fracClamped ?? 0, 4 / 7, 1e-12);
+
+  // RELU is "dead" when pre-activation <= 0 (activation becomes 0).
+  const relu = summariseDeadZoneStats("ReLU", [-2, -1, 0, 0.1, 2]);
+  assert(relu.n === 5);
+  approx(relu.fracAtZero ?? 0, 3 / 5, 1e-12);
+});
+
+Deno.test("summariseErrorConcentration flags heavy-tail distributions", async () => {
+  // Use dynamic import here for the same reason as summariseSeriesStats above.
+  const mod = (await import("../impact_diagnostics.js")) as unknown as Record<
+    string,
+    unknown
+  >;
+  const summariseErrorConcentration = mod.summariseErrorConcentration as
+    | ((contrib: number[], options?: { topK?: number }) => {
+      n: number;
+      total: number;
+      topK: { index: number; value: number; shareOfTotal: number }[];
+      topKShare: number;
+    })
+    | undefined;
+
+  assert(
+    typeof summariseErrorConcentration === "function",
+    "Expected summariseErrorConcentration to be a function export",
+  );
+
+  // One obs dominates total squared error.
+  const s = summariseErrorConcentration([100, 1, 1, 1, 1], { topK: 2 });
+  assert(s.total > 0);
+  assert(s.topK.length === 2);
+  // Top-1 share should be very high.
+  assert(
+    (s.topK[0]?.shareOfTotal ?? 0) > 0.9,
+    "Expected the top observation to dominate total error",
+  );
+});

--- a/tests/mobile_tooltip_test.ts
+++ b/tests/mobile_tooltip_test.ts
@@ -26,6 +26,21 @@ Deno.test("tooltips work on mobile via press-and-hold", async () => {
     js.includes("touchTooltip"),
     `Expected ${appPath} to create a tooltip UI container`,
   );
+
+  // Toggle-to-close must work on touch devices. `touchstart` fires before `click`,
+  // so we must not clear the "currently shown for" state during `touchstart`,
+  // otherwise the click handler can never detect a second tap on the same target.
+  const touchstartIdx = js.indexOf('document.addEventListener(\n    "touchstart"');
+  const findTargetIdx = js.indexOf("const target = findTooltipTarget(e.target);");
+  assert(
+    touchstartIdx >= 0 && findTargetIdx > touchstartIdx,
+    `Expected ${appPath} to include a touchstart handler that looks up tooltip targets`,
+  );
+  const between = js.slice(touchstartIdx, findTargetIdx);
+  assert(
+    !between.includes("shownForTarget = null"),
+    `Expected ${appPath} not to clear shownForTarget during touchstart (would break toggle-to-close)`,
+  );
   assert(
     js.includes('document.addEventListener(\n    "click"') ||
       js.includes('document.addEventListener("click"'),
@@ -40,6 +55,23 @@ Deno.test("tooltips work on mobile via press-and-hold", async () => {
     js.includes("suppressClickUntil") &&
       js.includes("Date.now() < suppressClickUntil"),
     `Expected ${appPath} to suppress click toggling within suppressClickUntil window`,
+  );
+
+  // When a tooltip is open, touching a tooltip target should not be treated as an
+  // "outside" touch-close event, otherwise a tap-to-toggle will close on touchstart
+  // then immediately re-open on click.
+  const outsideTouchIdx = js.indexOf("// Tap anywhere outside the tooltip to close it.");
+  assert(
+    outsideTouchIdx >= 0,
+    `Expected ${appPath} to include the outside-touch close handler`,
+  );
+  const outsideTouchGuardIdx = js.indexOf(
+    "if (findTooltipTarget(e.target)) return;",
+    outsideTouchIdx,
+  );
+  assert(
+    outsideTouchGuardIdx > outsideTouchIdx,
+    `Expected ${appPath} outside-touch close handler to ignore tooltip targets (avoid close-then-reopen race)`,
   );
   const outsideClickIdx = js.indexOf("Support outside-click close as well");
   assert(

--- a/tests/mobile_tooltip_test.ts
+++ b/tests/mobile_tooltip_test.ts
@@ -26,6 +26,16 @@ Deno.test("tooltips work on mobile via press-and-hold", async () => {
     js.includes("touchTooltip"),
     `Expected ${appPath} to create a tooltip UI container`,
   );
+  assert(
+    js.includes('document.addEventListener(\n    "click"') ||
+      js.includes('document.addEventListener("click"'),
+    `Expected ${appPath} to listen for click events (tap-to-show tooltips)`,
+  );
+  assert(
+    js.includes("isKnownTooltipEl") || js.includes("hasTooltip") ||
+      js.includes('classList?.contains("stat")'),
+    `Expected ${appPath} to scope tap-to-show tooltips to known tooltip elements`,
+  );
 
   const cssPath = repoPath("docs", "styles.css");
   const css = await Deno.readTextFile(cssPath);

--- a/tests/mobile_tooltip_test.ts
+++ b/tests/mobile_tooltip_test.ts
@@ -41,6 +41,18 @@ Deno.test("tooltips work on mobile via press-and-hold", async () => {
       js.includes("Date.now() < suppressClickUntil"),
     `Expected ${appPath} to suppress click toggling within suppressClickUntil window`,
   );
+  const outsideClickIdx = js.indexOf("Support outside-click close as well");
+  assert(
+    outsideClickIdx >= 0,
+    `Expected ${appPath} to include the outside-click-close handler`,
+  );
+  const outsideGuardIdx = js.indexOf(
+    "if (findTooltipTarget(e.target)) return;",
+  );
+  assert(
+    outsideGuardIdx > outsideClickIdx,
+    `Expected ${appPath} outside-click-close handler to ignore tooltip targets (avoid open-then-close race)`,
+  );
 
   const cssPath = repoPath("docs", "styles.css");
   const css = await Deno.readTextFile(cssPath);

--- a/tests/mobile_tooltip_test.ts
+++ b/tests/mobile_tooltip_test.ts
@@ -30,8 +30,12 @@ Deno.test("tooltips work on mobile via press-and-hold", async () => {
   // Toggle-to-close must work on touch devices. `touchstart` fires before `click`,
   // so we must not clear the "currently shown for" state during `touchstart`,
   // otherwise the click handler can never detect a second tap on the same target.
-  const touchstartIdx = js.indexOf('document.addEventListener(\n    "touchstart"');
-  const findTargetIdx = js.indexOf("const target = findTooltipTarget(e.target);");
+  const touchstartIdx = js.indexOf(
+    'document.addEventListener(\n    "touchstart"',
+  );
+  const findTargetIdx = js.indexOf(
+    "const target = findTooltipTarget(e.target);",
+  );
   assert(
     touchstartIdx >= 0 && findTargetIdx > touchstartIdx,
     `Expected ${appPath} to include a touchstart handler that looks up tooltip targets`,
@@ -60,7 +64,9 @@ Deno.test("tooltips work on mobile via press-and-hold", async () => {
   // When a tooltip is open, touching a tooltip target should not be treated as an
   // "outside" touch-close event, otherwise a tap-to-toggle will close on touchstart
   // then immediately re-open on click.
-  const outsideTouchIdx = js.indexOf("// Tap anywhere outside the tooltip to close it.");
+  const outsideTouchIdx = js.indexOf(
+    "// Tap anywhere outside the tooltip to close it.",
+  );
   assert(
     outsideTouchIdx >= 0,
     `Expected ${appPath} to include the outside-touch close handler`,
@@ -80,6 +86,7 @@ Deno.test("tooltips work on mobile via press-and-hold", async () => {
   );
   const outsideGuardIdx = js.indexOf(
     "if (findTooltipTarget(e.target)) return;",
+    outsideClickIdx,
   );
   assert(
     outsideGuardIdx > outsideClickIdx,

--- a/tests/mobile_tooltip_test.ts
+++ b/tests/mobile_tooltip_test.ts
@@ -36,6 +36,11 @@ Deno.test("tooltips work on mobile via press-and-hold", async () => {
       js.includes('classList?.contains("stat")'),
     `Expected ${appPath} to scope tap-to-show tooltips to known tooltip elements`,
   );
+  assert(
+    js.includes("suppressClickUntil") &&
+      js.includes("Date.now() < suppressClickUntil"),
+    `Expected ${appPath} to suppress click toggling within suppressClickUntil window`,
+  );
 
   const cssPath = repoPath("docs", "styles.css");
   const css = await Deno.readTextFile(cssPath);

--- a/tests/pre_activation_ui_test.ts
+++ b/tests/pre_activation_ui_test.ts
@@ -1,0 +1,33 @@
+function assert(condition: unknown, message?: string): asserts condition {
+  if (!condition) throw new Error(message ?? "Assertion failed");
+}
+
+function repoPath(...parts: string[]): string {
+  const url = new URL(import.meta.url);
+  const here = url.pathname;
+  // .../tests/pre_activation_ui_test.ts -> repo root
+  const root = here.replace(/\/tests\/pre_activation_ui_test\.ts$/, "");
+  return [root, ...parts].join("/");
+}
+
+Deno.test("neuron panel shows pre-activation (net input) stats", async () => {
+  const appPath = repoPath("docs", "app.js");
+  const js = await Deno.readTextFile(appPath);
+
+  assert(
+    js.includes("Pre-activation mean"),
+    `Expected ${appPath} to include a 'Pre-activation mean' row`,
+  );
+  assert(
+    js.includes("Pre-activation range"),
+    `Expected ${appPath} to include a 'Pre-activation range' row`,
+  );
+  assert(
+    js.includes("summariseSeriesStats"),
+    `Expected ${appPath} to compute pre-activation stats via summariseSeriesStats`,
+  );
+  assert(
+    js.includes("net input") || js.includes("Pre-activation (net input)"),
+    `Expected ${appPath} to use the 'net input' terminology`,
+  );
+});

--- a/tests/split_synapse_candidate_ui_test.ts
+++ b/tests/split_synapse_candidate_ui_test.ts
@@ -1,0 +1,54 @@
+function assert(condition: unknown, message?: string): asserts condition {
+  if (!condition) throw new Error(message ?? "Assertion failed");
+}
+
+function repoPath(...parts: string[]): string {
+  const url = new URL(import.meta.url);
+  const here = url.pathname;
+  // .../tests/split_synapse_candidate_ui_test.ts -> repo root
+  const root = here.replace(
+    /\/tests\/split_synapse_candidate_ui_test\.ts$/,
+    "",
+  );
+  return [root, ...parts].join("/");
+}
+
+Deno.test("UI supports split-synapse insert-neuron discovery candidates", async () => {
+  const appPath = repoPath("docs", "app.js");
+  const js = await Deno.readTextFile(appPath);
+
+  assert(
+    js.includes("split_synapse_insert_neuron"),
+    `Expected ${appPath} to mention the split_synapse_insert_neuron candidate type`,
+  );
+  assert(
+    js.includes("Synapse count Δ") || js.includes("Synapse count delta"),
+    `Expected ${appPath} to include a before/after synapse count delta summary`,
+  );
+  assert(
+    js.includes("Neuron count Δ") || js.includes("Neuron count delta"),
+    `Expected ${appPath} to include a before/after neuron count delta summary`,
+  );
+  assert(
+    js.includes("Removed synapse") || js.includes("Removed edge"),
+    `Expected ${appPath} to describe which synapse is removed in the diff view`,
+  );
+});
+
+Deno.test("UI includes an Issues tab (28-Dec-2025)", async () => {
+  const htmlPath = repoPath("docs", "index.html");
+  const html = await Deno.readTextFile(htmlPath);
+
+  assert(
+    html.includes("Issues"),
+    `Expected ${htmlPath} to include an Issues tab label`,
+  );
+  assert(
+    html.includes("neuronTabIssues"),
+    `Expected ${htmlPath} to include a #neuronTabIssues button`,
+  );
+  assert(
+    html.includes("neuronTabPanelIssues"),
+    `Expected ${htmlPath} to include a #neuronTabPanelIssues container`,
+  );
+});


### PR DESCRIPTION
… series

- Introduced `summariseSeriesStats` to compute key statistics (mean, std, min, max, percentiles) for numeric arrays, aiding in the detection of scale issues in pre-activations.
- Updated `app.js` to integrate the new function for pre-activation diagnostics, enhancing the analysis capabilities.
- Enhanced tooltip descriptions to provide insights on pre-activation statistics in the UI.
- Added tests to validate the functionality of `summariseSeriesStats`, ensuring accurate statistical computations.

This commit significantly improves the diagnostic tools available for analyzing pre-activation values in the application.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces richer diagnostics and discovery workflows in the explorer UI.
> 
> - **New diagnostics:** Adds `summariseSeriesStats`, `summariseDeadZoneStats`, and `summariseErrorConcentration` and integrates them to compute pre‑activation stats, saturation/dead‑zone rates, non‑finite/error concentration, and input redundancy.
> - **UI tabs:** Adds `Details`/`Issues`/`Candidates` tabs; Issues tab shows flagged neurons and input issues; Candidates tab lists discovery candidates with a split‑synapse insert‑neuron diagram and before/after diffs.
> - **Explorer updates:** Displays pre‑activation (net input) stats in neuron props; highlights the synapse to be replaced for a selected candidate in the inbound list.
> - **Mobile UX:** Refines touch tooltip behavior (tap/press‑and‑hold, outside‑tap close) and scopes tooltip targets.
> - **Styles/markup:** Updates `index.html` and `styles.css` for tabs, panels, diagrams, and states.
> - **Tests:** Adds tests for series stats, dead‑zone/error concentration summaries, mobile tooltip behavior, pre‑activation UI, and split‑synapse candidate UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e7976ad3d3959d892208d345de2670a6114f4b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->