### PR TITLE
Enhance service worker and server logic for multi-entry point navigation

### DIFF
--- a/docs/sw.js
+++ b/docs/sw.js
@@ -160,7 +160,25 @@ self.addEventListener("fetch", (event) => {
   // Navigation -> cached index.html as app shell.
   if (request.mode === "navigate") {
     if (!sameOrigin) return;
-    event.respondWith(cacheFirst("./index.html"));
+    // This site has multiple entry points under docs/:
+    // - ./index.html (Explorer)
+    // - ./starfield/index.html (Starfield)
+    //
+    // IMPORTANT: If we always serve "./index.html" for navigation, then visiting
+    // "/starfield/" will load the explorer HTML, and its relative asset URLs
+    // (./styles.css, ./app.js) will resolve under "/starfield/" and 404.
+    // That produces a blank/unstyled page.
+    const path = (() => {
+      try {
+        return new URL(request.url).pathname;
+      } catch {
+        return "";
+      }
+    })();
+    const isStarfieldNav = /\/starfield(\/|$)/.test(path);
+    event.respondWith(
+      cacheFirst(isStarfieldNav ? "./starfield/index.html" : "./index.html"),
+    );
     return;
   }
 

--- a/helpers/server.ts
+++ b/helpers/server.ts
@@ -32,6 +32,16 @@ function shouldSpaFallback(req: Request): boolean {
   return req.method === "GET" && accept.includes("text/html");
 }
 
+function spaEntryPointForPath(pathname: string): string {
+  // This repo publishes multiple entry points under docs/:
+  // - /index.html (Explorer)
+  // - /starfield/index.html (Starfield)
+  //
+  // Local dev should mirror GitHub Pages so links like /starfield/ work.
+  if (/^\/starfield(\/|$)/.test(pathname)) return "/starfield/index.html";
+  return "/index.html";
+}
+
 function resolveServeDir(repoRoot: string, dirArg: string | undefined): string {
   const dir = (dirArg ?? "docs").trim() || "docs";
   // Prevent accidental path traversal outside repo root.
@@ -63,7 +73,7 @@ Deno.serve(
     if (shouldSpaFallback(req)) {
       const url = new URL(req.url);
       const indexUrl = new URL(url);
-      indexUrl.pathname = "/index.html";
+      indexUrl.pathname = spaEntryPointForPath(url.pathname);
       return await serveDir(new Request(indexUrl, req), { fsRoot });
     }
 

--- a/tests/pwa_test.ts
+++ b/tests/pwa_test.ts
@@ -111,6 +111,16 @@ Deno.test("service worker caches the app shell", async () => {
       `Expected service worker to include ${mustInclude} in STATIC_FILES`,
     );
   }
+
+  // Ensure navigation routing serves the correct app shell for /starfield/.
+  assert(
+    sw.includes('request.mode === "navigate"'),
+    "Expected service worker to handle navigation requests",
+  );
+  assert(
+    sw.includes("./starfield/index.html"),
+    "Expected service worker to route /starfield/ navigations to ./starfield/index.html",
+  );
 });
 
 Deno.test("app loads tooltips from snapshot (not Tooltips.json)", async () => {

--- a/tests/server_script_test.ts
+++ b/tests/server_script_test.ts
@@ -29,6 +29,11 @@ Deno.test("helpers/server.ts uses JSR std http file server", async () => {
     text.includes("@std/http/file-server"),
     "Expected helpers/server.ts to import @std/http/file-server (via deno.json imports)",
   );
+  assert(
+    text.includes("spaEntryPointForPath") &&
+      text.includes("/starfield/index.html"),
+    "Expected helpers/server.ts SPA fallback to route /starfield/ to /starfield/index.html",
+  );
 });
 
 Deno.test("deno.json pins JSR std imports", async () => {


### PR DESCRIPTION
- Updated the service worker to correctly serve the app shell for multiple entry points, specifically handling navigation requests for the Starfield view.
- Introduced a new function in the server helper to determine the appropriate SPA entry point based on the requested path.
- Added tests to ensure the correct routing for navigation requests to both the Explorer and Starfield views.

These changes improve the user experience by ensuring that the correct HTML is served based on the navigation path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves multi-entry SPA routing for the PWA and local dev server.
> 
> - Service worker navigation handling now serves `./starfield/index.html` when navigating under `/starfield/`, otherwise `./index.html`, preventing broken relative assets
> - Dev server adds `spaEntryPointForPath()` and uses it in SPA fallback so `/starfield/` routes to `/starfield/index.html`, mirroring GitHub Pages
> - Tests updated to assert service worker navigation handling and server fallback behavior for the Starfield entry, alongside existing cache list checks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 575f375ae51f7674839dc6914d559246d5cd7eb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->