### PR TITLE
Make pwa

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # NEAT-AI Explore
 
-A static HTML/JS/CSS viewer for exploring NEAT-AI creature snapshots. This is a
-debug tool for investigating why discovery candidates fail or succeed.
+A static HTML/JS/CSS viewer for exploring a **NEAT network snapshot** (neurons,
+synapses, impacts, and recorded activations). This is a debug tool for
+investigating why discovery candidates fail or succeed.
 
 ## Try it now (example snapshot)
 
-- **Explorer (trace view)**:
+- **Trace explorer**:
   [Open Explorer on GitHub Pages](https://stsoftwareau.github.io/NEAT-AI-Explore/)
-- **Starfield (3D neighbourhood view)**:
-  [Open Starfield on GitHub Pages](https://stsoftwareau.github.io/NEAT-AI-Explore/starfield/)
+- **Graph explorer (3D neighbourhood view)**:
+  [Open Graph Explorer on GitHub Pages](https://stsoftwareau.github.io/NEAT-AI-Explore/starfield/)
 - **Snapshot repo (default example snapshot)**:
   [NEAT-AI-Snapshot](https://github.com/stSoftwareAU/NEAT-AI-Snapshot)
   (published via GitHub Pages as
@@ -111,7 +112,7 @@ Also note:
 
 ## Features
 
-- **Trace Explorer**: Click an output neuron → see inbound synapses → click to
+- **Trace explorer**: Click an output neuron → see inbound synapses → click to
   go upstream toward observations → repeat until you reach inputs. Builds a
   breadcrumb trail.
 - **Synapse Sorting**: Sort inbound synapses by |weight|, weight, or |mean
@@ -120,6 +121,8 @@ Also note:
   stats.
 - **Reconstruction Checks**: If enabled in export, shows max value/activation
   deltas to identify recording or squash function mismatches.
+- **Graph explorer**: A 3D neighbourhood view of the NEAT network to build
+  intuition about local connectivity and high-impact pathways.
 
 ## What the Explorer shows (example snapshot)
 
@@ -169,31 +172,31 @@ viewports (see `scripts/generate_pwa_assets.py`).
 
 ![Desktop inbound modal](docs/screenshots/desktop-inbound-modal.png)
 
-## Starfield view (Issue #25)
+## Graph explorer (3D neighbourhood view)
 
-The starfield view is a fun/intuition-building alternative visualisation for
-large creatures.
+The graph explorer is an intuition-building alternative visualisation for large
+NEAT networks.
 
-- **Entry point**: `docs/starfield/index.html`
+- **Entry point**: `docs/starfield/index.html` (folder name is historical)
 - **Controls**:
   - Drag to look
   - Mouse wheel to zoom
   - WASD / arrow keys to fly
   - Click a star to focus it (HUD shows key properties + flags)
 - **Layout**: focus-centric neighbourhood view (directly linked neurons are
-  closest; moving focus recomputes the local starfield)
+  closest; moving focus recomputes the local neighbourhood layout)
 
-### Starfield (desktop)
+### Graph explorer (desktop)
 
-![Starfield desktop](docs/screenshots/starfield-desktop.png)
+![Graph explorer desktop](docs/screenshots/starfield-desktop.png)
 
-### Starfield (click-to-focus HUD)
+### Graph explorer (click-to-focus HUD)
 
-![Starfield focus HUD](docs/screenshots/starfield-desktop-focus.png)
+![Graph explorer focus HUD](docs/screenshots/starfield-desktop-focus.png)
 
-### Starfield (tilt + zoom)
+### Graph explorer (tilt + zoom)
 
-![Starfield tilt](docs/screenshots/starfield-desktop-tilt.png)
+![Graph explorer tilt](docs/screenshots/starfield-desktop-tilt.png)
 
 ## Direction terminology (to avoid confusion)
 
@@ -279,7 +282,7 @@ Outputs:
 - `docs/screenshots/ipad-screenshot.png`
 - `docs/screenshots/ipad-inbound-modal.png`
 
-Last updated: 20-Dec-2025
+Last updated: 31-Dec-2025
 
 ## Licence
 

--- a/docs/starfield/index.html
+++ b/docs/starfield/index.html
@@ -34,20 +34,32 @@
     <header class="appHeader">
       <h1>NEAT-AI Graph</h1>
       <div class="headerControls">
-        <input
-          id="fetchUrl"
-          class="input"
-          placeholder="https://stsoftwareau.github.io/NEAT-AI-Snapshot/snapshot.json.gz"
-        />
-        <button id="fetchBtn" class="button">Fetch</button>
-        <input
-          id="fileInput"
-          type="file"
-          accept="application/json,.json,.gz,application/gzip,application/x-gzip"
-          style="display: none"
-        />
+        <details id="snapshotDetails" class="snapshotDetails" open>
+          <summary
+            class="button buttonSecondary buttonSmall snapshotSummary"
+            aria-label="Snapshot loader"
+            title="Snapshot loader"
+          >
+            Snapshot
+          </summary>
+          <div class="snapshotPanel" role="group" aria-label="Snapshot loader">
+            <input
+              id="fetchUrl"
+              class="input"
+              placeholder="https://stsoftwareau.github.io/NEAT-AI-Snapshot/snapshot.json.gz"
+            />
+            <button id="fetchBtn" class="button">Fetch</button>
+            <input
+              id="fileInput"
+              type="file"
+              accept="application/json,.json,.gz,application/gzip,application/x-gzip"
+              style="display: none"
+            />
+            <button id="fileBtn" class="button">Browse…</button>
+          </div>
+        </details>
+
         <div class="browseGroup">
-          <button id="fileBtn" class="button">Browse…</button>
           <button
             id="backBtn"
             class="button buttonSecondary"
@@ -66,16 +78,6 @@
             title="Mode: Impact Flow (tap to toggle)"
           >
             Impact
-          </button>
-          <button
-            id="themeToggle"
-            class="button buttonSecondary themeToggle"
-            type="button"
-            aria-label="Theme: Dark (locked)"
-            title="Theme: Dark (locked)"
-            disabled
-          >
-            ☾
           </button>
         </div>
         <div

--- a/docs/starfield/index.html
+++ b/docs/starfield/index.html
@@ -13,8 +13,22 @@
       media="(prefers-color-scheme: dark)"
     />
 
-    <link rel="stylesheet" href="./starfield.css" />
+    <link rel="stylesheet" href="./starfield.css?v=__BUILD_ID__" />
+    <link rel="manifest" href="../manifest.webmanifest" />
     <link rel="icon" href="../favicon.ico" />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="../icons/icon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="../icons/icon-16x16.png"
+    />
+    <link rel="apple-touch-icon" href="../icons/icon-192x192.png" />
   </head>
   <body>
     <header class="appHeader">
@@ -130,6 +144,37 @@
       </div>
     </main>
 
-    <script type="module" src="./starfield.js"></script>
+    <script type="module">
+      // Register the Service Worker *before* importing the graph explorer module.
+      //
+      // The graph explorer auto-loads the default snapshot on boot, and some
+      // environments (notably iOS/PWA) can fail the first fetch until the
+      // Service Worker has installed/activated. By awaiting SW readiness here,
+      // we avoid a first-load failure that succeeds on manual retry.
+      //
+      // Note: `navigator.serviceWorker.ready` never rejects and can remain
+      // pending forever if installation/activation fails. Use a timeout so the
+      // app still boots in degraded mode.
+      (async () => {
+        if ("serviceWorker" in navigator) {
+          try {
+            await navigator.serviceWorker.register(
+              "../sw.js?v=__BUILD_ID__",
+            );
+            const sleep = (ms) =>
+              new Promise((resolve) => setTimeout(resolve, ms));
+            await Promise.race([
+              navigator.serviceWorker.ready,
+              sleep(2000),
+            ]);
+          } catch (err) {
+            console.warn("SW registration failed:", err);
+          }
+        }
+
+        // Start the app once SW registration has had a chance to settle.
+        await import("./starfield.js?v=__BUILD_ID__");
+      })();
+    </script>
   </body>
 </html>

--- a/docs/starfield/starfield.css
+++ b/docs/starfield/starfield.css
@@ -118,6 +118,38 @@ body {
   gap: 6px;
 }
 
+.snapshotDetails {
+  /* Collapsible loader so the header stays tidy after a snapshot loads
+   * (Issue #37, 31-Dec-2025).
+   */
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+@media (min-width: 920px) {
+  .snapshotDetails {
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
+.snapshotDetails > summary {
+  list-style: none;
+}
+
+.snapshotDetails > summary::-webkit-details-marker {
+  display: none;
+}
+
+.snapshotPanel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .input {
   padding: 6px 10px;
   border-radius: 6px;
@@ -156,17 +188,6 @@ body {
 
 .buttonSecondary {
   background: var(--buttonSecondaryBg);
-}
-
-.button.themeToggle {
-  width: 38px;
-  min-width: 38px;
-  padding: 6px 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 700;
-  letter-spacing: 0.2px;
 }
 
 .statusInline {
@@ -235,6 +256,10 @@ body {
   height: 100%;
   display: block;
   background: transparent;
+  /* Ensure touch devices can drag/pinch the canvas without the browser
+   * interpreting gestures as page scroll/zoom (Issue #39, 31-Dec-2025).
+   */
+  touch-action: none;
 }
 
 .labelOverlay {

--- a/docs/starfield/starfield.js
+++ b/docs/starfield/starfield.js
@@ -1130,6 +1130,7 @@ class StarfieldRenderer {
 
     // Input state
     this.drag = { active: false, lastX: 0, lastY: 0 };
+    this.pinch = { active: false, lastDist: 0 };
     this.keys = new Set();
     this.focusIndex = -1;
 
@@ -1163,21 +1164,78 @@ class StarfieldRenderer {
       this.pitch = clamp(this.pitch, -1.35, 1.35);
     });
 
-    // Touch drag
+    // Touch controls:
+    // - 1 finger: look (yaw/pitch)
+    // - 2 fingers: pinch zoom (Issue #39, 31-Dec-2025)
+    const touchDistance = (t0, t1) =>
+      Math.hypot(t0.clientX - t1.clientX, t0.clientY - t1.clientY);
+
     c.addEventListener("touchstart", (e) => {
-      const t = e.touches[0];
-      if (!t) return;
+      const ts = e.touches;
+      if (!ts || ts.length === 0) return;
+
+      // Pinch zoom initialisation.
+      if (ts.length >= 2) {
+        this.pinch.active = true;
+        this.drag.active = false;
+        this.pinch.lastDist = touchDistance(ts[0], ts[1]);
+        return;
+      }
+
+      const t = ts[0];
       this.drag.active = true;
+      this.pinch.active = false;
       this.drag.lastX = t.clientX;
       this.drag.lastY = t.clientY;
-    }, { passive: true });
-    window.addEventListener("touchend", () => (this.drag.active = false), {
-      passive: true,
-    });
+    }, { passive: false });
+
+    window.addEventListener("touchend", (e) => {
+      const ts = e.touches;
+      if (!ts || ts.length === 0) {
+        this.drag.active = false;
+        this.pinch.active = false;
+        return;
+      }
+
+      // If we lifted one finger but still have one touch, transition back to
+      // look mode smoothly.
+      if (ts.length === 1) {
+        const t = ts[0];
+        this.drag.active = true;
+        this.pinch.active = false;
+        this.drag.lastX = t.clientX;
+        this.drag.lastY = t.clientY;
+        return;
+      }
+
+      // Still pinching (2+ fingers).
+      this.pinch.active = true;
+      this.drag.active = false;
+      this.pinch.lastDist = touchDistance(ts[0], ts[1]);
+    }, { passive: false });
+
     window.addEventListener("touchmove", (e) => {
+      const ts = e.touches;
+      if (!ts || ts.length === 0) return;
+
+      // Prevent the browser from treating gestures as scroll/back/zoom when the
+      // user is manipulating the canvas.
+      e.preventDefault();
+
+      if (ts.length >= 2) {
+        // Pinch zoom.
+        const d = touchDistance(ts[0], ts[1]);
+        const dd = this.pinch.lastDist - d;
+        this.pinch.lastDist = d;
+
+        // Tuned so iPhone/iPad pinch feels similar to mouse wheel.
+        this.zoomBy(dd * 0.22);
+        return;
+      }
+
+      // Single-finger look.
       if (!this.drag.active) return;
-      const t = e.touches[0];
-      if (!t) return;
+      const t = ts[0];
       const dx = t.clientX - this.drag.lastX;
       const dy = t.clientY - this.drag.lastY;
       this.drag.lastX = t.clientX;
@@ -1185,7 +1243,7 @@ class StarfieldRenderer {
       this.yaw += dx * 0.005;
       this.pitch += dy * 0.005;
       this.pitch = clamp(this.pitch, -1.35, 1.35);
-    }, { passive: true });
+    }, { passive: false });
 
     window.addEventListener("keydown", (e) => {
       this.keys.add(e.key.toLowerCase());
@@ -1196,8 +1254,7 @@ class StarfieldRenderer {
 
     c.addEventListener("wheel", (e) => {
       e.preventDefault();
-      this.pos.z += e.deltaY * 0.05;
-      this.pos.z = clamp(this.pos.z, 20, 520);
+      this.zoomBy(e.deltaY * 0.09);
     }, { passive: false });
 
     c.addEventListener("click", (e) => {
@@ -1205,6 +1262,44 @@ class StarfieldRenderer {
       const idx = this.pickStarIndex(e.clientX, e.clientY);
       if (idx >= 0) this.setFocus(idx);
     });
+  }
+
+  getForwardVector() {
+    // Forward vector (yaw/pitch) in camera space.
+    const cy = Math.cos(this.yaw);
+    const sy = Math.sin(this.yaw);
+    const cp = Math.cos(this.pitch);
+    const sp = Math.sin(this.pitch);
+    return { x: sy * cp, y: -sp, z: cy * cp };
+  }
+
+  clampDistance(minDist, maxDist) {
+    const d = Math.hypot(this.pos.x, this.pos.y, this.pos.z);
+    if (!Number.isFinite(d) || d <= 1e-9) return;
+    if (d < minDist) {
+      const s = minDist / d;
+      this.pos.x *= s;
+      this.pos.y *= s;
+      this.pos.z *= s;
+    } else if (d > maxDist) {
+      const s = maxDist / d;
+      this.pos.x *= s;
+      this.pos.y *= s;
+      this.pos.z *= s;
+    }
+  }
+
+  zoomBy(delta) {
+    // Zoom along the current view direction, not world Z. This makes zoom feel
+    // correct after yaw/pitch and helps users “open up” the neighbourhood view
+    // to see linked neurons (Issue #39, 31-Dec-2025).
+    const f = this.getForwardVector();
+    this.pos.x += f.x * delta;
+    this.pos.y += f.y * delta;
+    this.pos.z += f.z * delta;
+
+    // Allow a wider zoom range than the original 520 limit.
+    this.clampDistance(20, 1400);
   }
 
   setData({ positions, colours, sizes, meta }) {
@@ -2109,10 +2204,21 @@ async function loadSnapshot(source, label) {
       `Observations: ${inputCount.toLocaleString()}, Neurons: ${neuronCount.toLocaleString()} & Synapses: ${graph.synapses.length.toLocaleString()}`,
       "ok",
     );
+
+    // Keep the header aligned: once a snapshot is loaded, collapse the loader
+    // controls (Fetch/Browse) unless the user re-opens them (Issue #37,
+    // 31-Dec-2025).
+    const details = document.getElementById("snapshotDetails");
+    if (details instanceof HTMLDetailsElement) details.open = false;
   } catch (e) {
     hideProgress();
     setStatus(e?.message ?? String(e), "bad");
     console.error(e);
+
+    // If load failed, keep the loader controls visible so the user can recover
+    // quickly without hunting for the panel.
+    const details = document.getElementById("snapshotDetails");
+    if (details instanceof HTMLDetailsElement) details.open = true;
   }
 }
 
@@ -2126,13 +2232,6 @@ function initStarfield() {
     document.documentElement.setAttribute("data-theme", "dark");
     const metas = document.querySelectorAll('meta[name="theme-color"]');
     for (const meta of metas) meta.setAttribute("content", "#0a0e1a");
-    const btn = document.getElementById("themeToggle");
-    if (btn instanceof HTMLButtonElement) {
-      btn.disabled = true;
-      btn.textContent = "☾";
-      btn.title = "Theme: Dark (locked)";
-      btn.setAttribute("aria-label", btn.title);
-    }
   } catch (_e) {
     // No-op.
   }

--- a/docs/starfield/starfield.js
+++ b/docs/starfield/starfield.js
@@ -1131,6 +1131,10 @@ class StarfieldRenderer {
     // Input state
     this.drag = { active: false, lastX: 0, lastY: 0 };
     this.pinch = { active: false, lastDist: 0 };
+    // Touch gesture origin tracking: prevents off-canvas gestures (e.g. header
+    // inputs/buttons) from accidentally enabling camera look/zoom via the
+    // window-level touchend/touchmove handlers (Issue #41, 31-Dec-2025).
+    this.touch = { startedOnCanvas: false };
     this.keys = new Set();
     this.focusIndex = -1;
 
@@ -1174,6 +1178,10 @@ class StarfieldRenderer {
       const ts = e.touches;
       if (!ts || ts.length === 0) return;
 
+      // This handler is bound to the canvas; if it fires, the touch gesture
+      // began on the canvas.
+      this.touch.startedOnCanvas = true;
+
       // Pinch zoom initialisation.
       if (ts.length >= 2) {
         this.pinch.active = true;
@@ -1192,6 +1200,16 @@ class StarfieldRenderer {
     window.addEventListener("touchend", (e) => {
       const ts = e.touches;
       if (!ts || ts.length === 0) {
+        this.drag.active = false;
+        this.pinch.active = false;
+        this.touch.startedOnCanvas = false;
+        return;
+      }
+
+      // Important: touchend fires at window scope, including for gestures that
+      // began on non-canvas UI. Never enable drag/pinch unless the current touch
+      // gesture started on the canvas (Issue #41, 31-Dec-2025).
+      if (!this.touch.startedOnCanvas) {
         this.drag.active = false;
         this.pinch.active = false;
         return;
@@ -1214,15 +1232,28 @@ class StarfieldRenderer {
       this.pinch.lastDist = touchDistance(ts[0], ts[1]);
     }, { passive: false });
 
+    window.addEventListener("touchcancel", () => {
+      this.drag.active = false;
+      this.pinch.active = false;
+      this.touch.startedOnCanvas = false;
+    }, { passive: true });
+
     window.addEventListener("touchmove", (e) => {
+      if (!this.touch.startedOnCanvas) return;
       const ts = e.touches;
       if (!ts || ts.length === 0) return;
 
-      // Prevent the browser from treating gestures as scroll/back/zoom when the
-      // user is manipulating the canvas.
-      e.preventDefault();
-
       if (ts.length >= 2) {
+        // If the gesture didn't start on the canvas, don't treat it as a pinch.
+        // Without this guard, a 2-finger gesture that begins on non-canvas UI
+        // (e.g. header inputs) can cause a large zoom jump because pinch.lastDist
+        // was never initialised (Issue #40, 31-Dec-2025).
+        if (!this.pinch.active) return;
+
+        // Prevent the browser from treating gestures as scroll/back/zoom when
+        // the user is manipulating the canvas.
+        e.preventDefault();
+
         // Pinch zoom.
         const d = touchDistance(ts[0], ts[1]);
         const dd = this.pinch.lastDist - d;
@@ -1235,6 +1266,11 @@ class StarfieldRenderer {
 
       // Single-finger look.
       if (!this.drag.active) return;
+
+      // Prevent the browser from treating gestures as scroll/back/zoom when the
+      // user is manipulating the canvas.
+      e.preventDefault();
+
       const t = ts[0];
       const dx = t.clientX - this.drag.lastX;
       const dy = t.clientY - this.drag.lastY;

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -26,8 +26,8 @@ const STATIC_FILES = [
   // Starfield view (Issue #25): kept in its own folder to avoid destabilising
   // the existing explorer view.
   "./starfield/index.html",
-  "./starfield/starfield.js",
-  "./starfield/starfield.css",
+  `./starfield/starfield.js?v=${VERSION}`,
+  `./starfield/starfield.css?v=${VERSION}`,
   // Shared modules for multiple views.
   "./shared/snapshot_loader.js",
   "./shared/theme.js",

--- a/tests/first_fetch_race_test.ts
+++ b/tests/first_fetch_race_test.ts
@@ -61,3 +61,51 @@ Deno.test("service worker registers (and is awaited) before app auto-load runs (
     "Expected SW readiness timeout logic to occur before importing app.js",
   );
 });
+
+Deno.test("service worker registers (and is awaited) before graph explorer auto-load runs (31-Dec-2025)", async () => {
+  const indexPath = repoPath("docs", "starfield", "index.html");
+  const html = await Deno.readTextFile(indexPath);
+
+  // The graph explorer (starfield) also auto-loads the default snapshot on boot,
+  // so it must give the service worker time to install/activate before the
+  // first fetch runs (especially on iOS/PWA).
+  const swRegisterIdx = html.indexOf("navigator.serviceWorker.register");
+  const swReadyIdx = html.indexOf("navigator.serviceWorker.ready");
+  const promiseRaceIdx = html.indexOf("Promise.race");
+  const setTimeoutIdx = html.indexOf("setTimeout");
+  const appImportIdx = html.indexOf('import("./starfield.js?v=__BUILD_ID__")');
+
+  assert(
+    swRegisterIdx !== -1,
+    "Expected starfield/index.html to register a service worker",
+  );
+  assert(
+    swReadyIdx !== -1,
+    "Expected starfield/index.html to await navigator.serviceWorker.ready",
+  );
+  assert(
+    promiseRaceIdx !== -1,
+    "Expected starfield/index.html to use Promise.race for SW readiness timeout",
+  );
+  assert(
+    setTimeoutIdx !== -1,
+    "Expected starfield/index.html to use setTimeout for SW readiness timeout",
+  );
+  assert(
+    appImportIdx !== -1,
+    "Expected starfield/index.html to import starfield.js as a module",
+  );
+
+  assert(
+    swRegisterIdx < appImportIdx,
+    "Expected service worker registration to occur before importing starfield.js",
+  );
+  assert(
+    swReadyIdx < appImportIdx,
+    "Expected service worker readiness to be awaited before importing starfield.js",
+  );
+  assert(
+    promiseRaceIdx < appImportIdx,
+    "Expected SW readiness timeout logic to occur before importing starfield.js",
+  );
+});

--- a/tests/pwa_test.ts
+++ b/tests/pwa_test.ts
@@ -99,8 +99,8 @@ Deno.test("service worker caches the app shell", async () => {
       '"./favicon.ico"',
       '"./icons/icon-192x192.png"',
       '"./starfield/index.html"',
-      '"./starfield/starfield.js"',
-      '"./starfield/starfield.css"',
+      "`./starfield/starfield.js?v=${VERSION}`",
+      "`./starfield/starfield.css?v=${VERSION}`",
       '"./shared/snapshot_loader.js"',
       '"./shared/theme.js"',
       '"./shared/colour_maps.js"',
@@ -171,5 +171,47 @@ Deno.test("docs/index.html links manifest and registers service worker", async (
   assert(
     html.includes("sw.js?v=__BUILD_ID__"),
     "Expected docs/index.html to cache-bust sw.js with __BUILD_ID__",
+  );
+});
+
+Deno.test("docs/starfield/index.html links manifest and registers service worker", async () => {
+  const indexPath = repoPath("docs", "starfield", "index.html");
+  const html = await Deno.readTextFile(indexPath);
+
+  assert(
+    html.includes('rel="manifest"'),
+    "Expected docs/starfield/index.html to include a web manifest <link>",
+  );
+  assert(
+    html.includes("../manifest.webmanifest"),
+    'Expected docs/starfield/index.html to reference "../manifest.webmanifest"',
+  );
+  assert(
+    html.includes('rel="icon"') || html.includes('rel="shortcut icon"'),
+    'Expected docs/starfield/index.html to include a favicon <link rel="icon" ...>',
+  );
+  assert(
+    html.includes("../favicon.ico"),
+    'Expected docs/starfield/index.html to reference "../favicon.ico"',
+  );
+  assert(
+    html.includes("navigator.serviceWorker.register"),
+    "Expected docs/starfield/index.html to register a service worker",
+  );
+  assert(
+    html.includes("../sw.js"),
+    'Expected docs/starfield/index.html to reference "../sw.js"',
+  );
+  assert(
+    html.includes("starfield.js?v=__BUILD_ID__"),
+    "Expected docs/starfield/index.html to cache-bust starfield.js with __BUILD_ID__",
+  );
+  assert(
+    html.includes("starfield.css?v=__BUILD_ID__"),
+    "Expected docs/starfield/index.html to cache-bust starfield.css with __BUILD_ID__",
+  );
+  assert(
+    html.includes("sw.js?v=__BUILD_ID__"),
+    "Expected docs/starfield/index.html to cache-bust sw.js with __BUILD_ID__",
   );
 });

--- a/tests/starfield_dark_mode_locked_test.ts
+++ b/tests/starfield_dark_mode_locked_test.ts
@@ -13,21 +13,13 @@ function repoPath(...parts: string[]): string {
   return [root, ...parts].join("/");
 }
 
-Deno.test("starfield hard-locks dark mode for visibility (30-Dec-2025)", async () => {
+Deno.test("starfield hard-locks dark mode for visibility (and hides theme selector) (31-Dec-2025)", async () => {
   const htmlPath = repoPath("docs", "starfield", "index.html");
   const html = await Deno.readTextFile(htmlPath);
 
   assert(
-    html.includes('id="themeToggle"'),
-    `Expected ${htmlPath} to include the theme toggle button`,
-  );
-  assert(
-    /id="themeToggle"[\s\S]*disabled/.test(html),
-    `Expected ${htmlPath} to disable the theme toggle (locked dark mode)`,
-  );
-  assert(
-    /id="themeToggle"[\s\S]*?>\s*☾\s*</.test(html),
-    `Expected ${htmlPath} theme toggle glyph to be ☾ (dark)`,
+    !html.includes('id="themeToggle"'),
+    `Expected ${htmlPath} to omit the theme selector (Issue #38)`,
   );
 
   const jsPath = repoPath("docs", "starfield", "starfield.js");

--- a/tests/starfield_loader_panel_test.ts
+++ b/tests/starfield_loader_panel_test.ts
@@ -1,0 +1,41 @@
+function assert(condition: unknown, message?: string): asserts condition {
+  if (!condition) throw new Error(message ?? "Assertion failed");
+}
+
+function repoPath(...parts: string[]): string {
+  const url = new URL(import.meta.url);
+  const here = url.pathname;
+  // .../tests/starfield_loader_panel_test.ts -> repo root
+  const root = here.replace(/\/tests\/starfield_loader_panel_test\.ts$/, "");
+  return [root, ...parts].join("/");
+}
+
+Deno.test("graph explorer collapses loader controls after snapshot loads (Issue #37, 31-Dec-2025)", async () => {
+  const htmlPath = repoPath("docs", "starfield", "index.html");
+  const html = await Deno.readTextFile(htmlPath);
+
+  assert(
+    html.includes('id="snapshotDetails"'),
+    `Expected ${htmlPath} to include a <details id="snapshotDetails"> wrapper`,
+  );
+  assert(
+    html.includes("Snapshot"),
+    `Expected ${htmlPath} to include a Snapshot summary label`,
+  );
+
+  const jsPath = repoPath("docs", "starfield", "starfield.js");
+  const js = await Deno.readTextFile(jsPath);
+
+  assert(
+    js.includes('getElementById("snapshotDetails")'),
+    `Expected ${jsPath} to reference the snapshotDetails element`,
+  );
+  assert(
+    js.includes("details.open = false"),
+    `Expected ${jsPath} to auto-collapse snapshotDetails after a successful load`,
+  );
+  assert(
+    js.includes("details.open = true"),
+    `Expected ${jsPath} to expand snapshotDetails on load errors`,
+  );
+});

--- a/tests/starfield_touch_zoom_test.ts
+++ b/tests/starfield_touch_zoom_test.ts
@@ -23,6 +23,13 @@ Deno.test("starfield supports pinch-to-zoom on touch devices (Issue #39, 31-Dec-
     "Expected starfield.js to detect multi-touch for pinch zoom",
   );
   assert(
+    /if\s*\(ts\.length\s*>=\s*2\)\s*\{[\s\S]{0,400}this\.pinch\.active[\s\S]{0,400}zoomBy/
+      .test(
+        js,
+      ),
+    "Expected touchmove pinch branch to be gated by pinch.active to avoid zoom jumps",
+  );
+  assert(
     js.includes('addEventListener("touchmove"') &&
       js.includes("passive: false"),
     "Expected touchmove handler to be non-passive so it can preventDefault",
@@ -40,5 +47,23 @@ Deno.test("starfield canvas disables browser gesture handling (touch-action: non
   assert(
     css.includes(".glCanvas") && css.includes("touch-action: none"),
     "Expected starfield.css to set touch-action: none on the canvas",
+  );
+});
+
+Deno.test("starfield does not activate drag/pinch if a touch gesture started off-canvas (Issue #41, 31-Dec-2025)", async () => {
+  const jsPath = repoPath("docs", "starfield", "starfield.js");
+  const js = await Deno.readTextFile(jsPath);
+
+  assert(
+    js.includes("startedOnCanvas"),
+    "Expected starfield.js to track whether a touch gesture started on the canvas",
+  );
+  assert(
+    js.includes('addEventListener("touchend"'),
+    "Expected starfield.js to bind a touchend handler",
+  );
+  assert(
+    js.includes("if (!this.touch.startedOnCanvas)"),
+    "Expected touchend handler to bail out when the touch gesture started off-canvas",
   );
 });

--- a/tests/starfield_touch_zoom_test.ts
+++ b/tests/starfield_touch_zoom_test.ts
@@ -1,0 +1,44 @@
+function assert(condition: unknown, message?: string): asserts condition {
+  if (!condition) throw new Error(message ?? "Assertion failed");
+}
+
+function repoPath(...parts: string[]): string {
+  const url = new URL(import.meta.url);
+  const here = url.pathname;
+  // .../tests/starfield_touch_zoom_test.ts -> repo root
+  const root = here.replace(/\/tests\/starfield_touch_zoom_test\.ts$/, "");
+  return [root, ...parts].join("/");
+}
+
+Deno.test("starfield supports pinch-to-zoom on touch devices (Issue #39, 31-Dec-2025)", async () => {
+  const jsPath = repoPath("docs", "starfield", "starfield.js");
+  const js = await Deno.readTextFile(jsPath);
+
+  assert(
+    js.includes("pinch") && js.includes("zoomBy"),
+    "Expected starfield.js to include pinch state and zoomBy helper",
+  );
+  assert(
+    js.includes("touches") && js.includes("ts.length >= 2"),
+    "Expected starfield.js to detect multi-touch for pinch zoom",
+  );
+  assert(
+    js.includes('addEventListener("touchmove"') &&
+      js.includes("passive: false"),
+    "Expected touchmove handler to be non-passive so it can preventDefault",
+  );
+  assert(
+    js.includes("e.preventDefault()"),
+    "Expected touchmove handler to call preventDefault to stop browser scroll/zoom",
+  );
+});
+
+Deno.test("starfield canvas disables browser gesture handling (touch-action: none) (Issue #39, 31-Dec-2025)", async () => {
+  const cssPath = repoPath("docs", "starfield", "starfield.css");
+  const css = await Deno.readTextFile(cssPath);
+
+  assert(
+    css.includes(".glCanvas") && css.includes("touch-action: none"),
+    "Expected starfield.css to set touch-action: none on the canvas",
+  );
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens the Graph explorer (starfield) PWA and touch UX.
> 
> - Registers/awaits `sw.js` before importing `starfield.js` and cache-busts `starfield.(css|js)` via `__BUILD_ID__`; links manifest/icons in `docs/starfield/index.html`
> - Collapsible snapshot loader (`<details id="snapshotDetails">`) with "Fetch/Browse" panel; auto-collapses on successful load and expands on error
> - Touch improvements: pinch-to-zoom with non-passive handlers, `touch-action: none` on canvas, zoom along view direction, wider zoom range, and guards to ignore gestures started off-canvas
> - Locks Graph explorer to dark mode (removes theme toggle)
> - Service worker caches versioned starfield assets and maintains correct navigation routing
> - Adds/updates tests for SW readiness timing, PWA links/cache-busting, dark-mode lock, loader panel behaviour, and touch zoom/gesture guards
> - README updates to rename Starfield to Graph explorer and clarify features; refreshes "Last updated"
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 907d9c441d0c0418641abf4ef05048f77676acd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->