### PR TITLE
Fix: Can we use a star field emoji instead (#65)

### DIFF
--- a/docs/graph/index.html
+++ b/docs/graph/index.html
@@ -60,6 +60,13 @@
         </details>
 
         <div class="browseGroup">
+          <a
+            id="traceBtn"
+            class="button buttonSecondary"
+            href="../"
+            aria-label="Back to Trace explorer"
+            title="Back to Trace explorer"
+          >Trace</a>
           <button
             id="backBtn"
             class="button buttonSecondary"

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,11 +75,9 @@
             id="graphBtn"
             class="button buttonSmall buttonSecondary"
             href="./graph/"
-            aria-label="Open 3D graph view"
-            title="Open 3D graph view (new tab recommended)"
-          >
-            3D Graph
-          </a>
+            aria-label="Open 3D star field view"
+            title="Open 3D star field view"
+          >🌟</a>
         </div>
       </nav>
 

--- a/docs/starfield/index.html
+++ b/docs/starfield/index.html
@@ -62,6 +62,13 @@
         </details>
 
         <div class="browseGroup">
+          <a
+            id="traceBtn"
+            class="button buttonSecondary"
+            href="../"
+            aria-label="Back to Trace explorer"
+            title="Back to Trace explorer"
+          >Trace</a>
           <button
             id="backBtn"
             class="button buttonSecondary"

--- a/tests/graph_link_button_test.ts
+++ b/tests/graph_link_button_test.ts
@@ -14,7 +14,12 @@ Deno.test("trace view exposes a 3D graph link (Issue #44, 31-Dec-2025)", async (
   const htmlPath = repoPath("docs", "index.html");
   const html = await Deno.readTextFile(htmlPath);
   assert(
-    html.includes('id="graphBtn"') && html.includes("3D Graph"),
+    html.includes('id="graphBtn"'),
     "Expected docs/index.html to expose a 3D graph button (graphBtn)",
+  );
+  // Issue #65: button now uses star emoji instead of "3D Graph" text to save space
+  assert(
+    html.includes("🌟") || html.includes("⭐"),
+    "Expected graphBtn to use a star emoji (Issue #65)",
   );
 });

--- a/tests/starfield_emoji_button_test.ts
+++ b/tests/starfield_emoji_button_test.ts
@@ -1,0 +1,36 @@
+function assert(condition: unknown, message?: string): asserts condition {
+  if (!condition) throw new Error(message ?? "Assertion failed");
+}
+
+function repoPath(...parts: string[]): string {
+  const url = new URL(import.meta.url);
+  const here = url.pathname;
+  // .../tests/starfield_emoji_button_test.ts -> repo root
+  const root = here.replace(/\/tests\/starfield_emoji_button_test\.ts$/, "");
+  return [root, ...parts].join("/");
+}
+
+Deno.test("trace view uses star emoji for 3D graph button (Issue #65)", async () => {
+  const htmlPath = repoPath("docs", "index.html");
+  const html = await Deno.readTextFile(htmlPath);
+
+  assert(
+    html.includes('id="graphBtn"'),
+    "Expected docs/index.html to have a graph button with id graphBtn",
+  );
+
+  // The button should use a star emoji (🌟 or ⭐) instead of text "3D Graph"
+  // to save space on mobile devices
+  assert(
+    html.includes("🌟") || html.includes("⭐"),
+    "Expected graphBtn to use a star emoji (🌟 or ⭐) instead of text to save space (Issue #65)",
+  );
+
+  // Ensure the old "3D Graph" text is no longer used in the button
+  // (The graphBtn should not contain the literal text "3D Graph")
+  const graphBtnMatch = html.match(/<a[^>]*id="graphBtn"[^>]*>([^<]*)<\/a>/);
+  assert(
+    graphBtnMatch && !graphBtnMatch[1].includes("3D Graph"),
+    "Expected graphBtn to not contain '3D Graph' text (should use emoji instead)",
+  );
+});

--- a/tests/starfield_trace_back_link_test.ts
+++ b/tests/starfield_trace_back_link_test.ts
@@ -1,0 +1,29 @@
+function assert(condition: unknown, message?: string): asserts condition {
+  if (!condition) throw new Error(message ?? "Assertion failed");
+}
+
+function repoPath(...parts: string[]): string {
+  const url = new URL(import.meta.url);
+  const here = url.pathname;
+  // .../tests/starfield_trace_back_link_test.ts -> repo root
+  const root = here.replace(/\/tests\/starfield_trace_back_link_test\.ts$/, "");
+  return [root, ...parts].join("/");
+}
+
+Deno.test("starfield/graph view has a link back to trace view (Issue #65)", async () => {
+  const htmlPath = repoPath("docs", "graph", "index.html");
+  const html = await Deno.readTextFile(htmlPath);
+
+  // There should be a link or button to navigate back to the trace view
+  assert(
+    html.includes('id="traceBtn"') || html.includes('href="../"') ||
+      html.includes("href='../'") || html.includes("Trace"),
+    "Expected graph/index.html to have a way to navigate back to trace view (Issue #65)",
+  );
+
+  // The UI should indicate it's a navigation back to trace explorer
+  assert(
+    html.includes("Trace") || html.includes("trace"),
+    "Expected graph view to have a Trace link/button for navigation back",
+  );
+});


### PR DESCRIPTION
## Summary
Automated fix for issue #65

## Changes
This PR addresses the issue: **Can we use a star field emoji instead**

## Testing
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #65