### PR TITLE
Fix: First fetch often fails but second works (#67)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -478,6 +478,15 @@ function maybeAnnotateLoadedFromCache(obj, usedCache, cacheReason) {
   return obj;
 }
 
+// Maximum number of retry attempts for transient network failures (Issue #67).
+// The first fetch can fail during Service Worker activation or on unstable
+// connections. Automatic retries make the app more resilient.
+const FETCH_MAX_RETRIES = 2;
+
+// Initial delay (ms) before the first retry. Doubles on each subsequent retry
+// (exponential backoff) to give transient issues time to resolve.
+const FETCH_RETRY_DELAY_MS = 500;
+
 async function fetchJson(url) {
   const u = normaliseSnapshotUrl(url);
   const canUseCacheFallback = isSnapshotCacheAllowedUrl(u) &&
@@ -488,48 +497,66 @@ async function fetchJson(url) {
   let usedCache = false;
   let cacheReason = "";
 
-  // Network-first: always attempt the fresh version when possible.
-  try {
-    // `no-cache` tells the browser to revalidate when possible, while still
-    // allowing offline use of cached responses when the network is down.
-    res = await fetch(u, { cache: "no-cache" });
-  } catch (e) {
-    // Browser blocks cross-origin fetches without CORS headers (common with S3 presigned URLs).
-    // fetch() rejects with TypeError("Failed to fetch") in that case.
-    // However, same-origin URLs cannot have CORS issues - "Failed to fetch" for
-    // same-origin URLs is more likely an offline/network error (especially on Chrome).
-    // Only throw the CORS error for cross-origin URLs; same-origin should proceed
-    // to cache fallback.
-    if (e?.message === "Failed to fetch" && !canUseCacheFallback) {
-      throw new Error(
-        "Failed to fetch (likely CORS). If this is an S3 presigned URL, add a bucket CORS rule allowing origin https://stsoftwareau.github.io (GET/HEAD).",
-      );
-    }
+  // Network-first with retry: attempt the fresh version, retrying on transient
+  // network failures (Issue #67). This handles the common "first fetch fails,
+  // second works" scenario during Service Worker activation or on unstable
+  // mobile connections.
+  let lastError = null;
+  for (let attempt = 0; attempt <= FETCH_MAX_RETRIES; attempt++) {
+    try {
+      // `no-cache` tells the browser to revalidate when possible, while still
+      // allowing offline use of cached responses when the network is down.
+      res = await fetch(u, { cache: "no-cache" });
+      // Success - break out of retry loop.
+      lastError = null;
+      break;
+    } catch (e) {
+      lastError = e;
 
-    // GitHub Pages can be blocked by CORS on some networks. If the default
-    // snapshot URL fails, try the known fallbacks.
-    if (String(url) === DEFAULT_SNAPSHOT_URL) {
-      for (const fallback of SNAPSHOT_FALLBACK_URLS) {
-        if (!fallback || fallback === url) continue;
-        try {
-          return await fetchJson(fallback);
-        } catch (_e2) {
-          // Keep trying.
+      // Browser blocks cross-origin fetches without CORS headers (common with S3 presigned URLs).
+      // fetch() rejects with TypeError("Failed to fetch") in that case.
+      // However, same-origin URLs cannot have CORS issues - "Failed to fetch" for
+      // same-origin URLs is more likely an offline/network error (especially on Chrome).
+      // Only throw the CORS error for cross-origin URLs; same-origin should proceed
+      // to cache fallback.
+      if (e?.message === "Failed to fetch" && !canUseCacheFallback) {
+        throw new Error(
+          "Failed to fetch (likely CORS). If this is an S3 presigned URL, add a bucket CORS rule allowing origin https://stsoftwareau.github.io (GET/HEAD).",
+        );
+      }
+
+      // If this wasn't our last attempt, wait before retrying (exponential backoff).
+      if (attempt < FETCH_MAX_RETRIES) {
+        const delay = FETCH_RETRY_DELAY_MS * Math.pow(2, attempt);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        continue;
+      }
+
+      // All retries exhausted - try fallback URLs for the default snapshot.
+      // GitHub Pages can be blocked by CORS on some networks.
+      if (String(url) === DEFAULT_SNAPSHOT_URL) {
+        for (const fallback of SNAPSHOT_FALLBACK_URLS) {
+          if (!fallback || fallback === url) continue;
+          try {
+            return await fetchJson(fallback);
+          } catch (_e2) {
+            // Keep trying.
+          }
         }
       }
-    }
 
-    // Offline/unstable network: fall back to Cache Storage when available.
-    if (canUseCacheFallback) {
-      const cached = await caches.match(u);
-      if (cached) {
-        res = cached;
-        usedCache = true;
-        cacheReason = "offline";
+      // Offline/unstable network: fall back to Cache Storage when available.
+      if (canUseCacheFallback) {
+        const cached = await caches.match(u);
+        if (cached) {
+          res = cached;
+          usedCache = true;
+          cacheReason = "offline";
+        }
       }
-    }
 
-    if (!res) throw e;
+      if (!res) throw e;
+    }
   }
 
   // If the network returned an error (e.g., 503), try cache fallback (same-origin only).

--- a/docs/shared/snapshot_loader.js
+++ b/docs/shared/snapshot_loader.js
@@ -94,12 +94,22 @@ export async function gunzipToText(gzBytes) {
  * @property {boolean} indeterminate
  */
 
+// Maximum number of retry attempts for transient network failures (Issue #67).
+// The first fetch can fail during Service Worker activation or on unstable
+// connections. Automatic retries make the app more resilient.
+const FETCH_MAX_RETRIES = 2;
+
+// Initial delay (ms) before the first retry. Doubles on each subsequent retry
+// (exponential backoff) to give transient issues time to resolve.
+const FETCH_RETRY_DELAY_MS = 500;
+
 /**
  * Fetch and parse snapshot JSON, with optional gzip decode and progress reporting.
  *
  * Notes:
  * - This is a best-effort loader for a debug PWA; it prefers compatibility and
  *   clear errors over cleverness.
+ * - Network-first with retry: retries on transient network failures (Issue #67).
  *
  * @param {string} url
  * @param {{
@@ -120,7 +130,29 @@ export async function fetchSnapshotJson(url, opts = {}) {
     }
   };
 
-  const res = await fetch(u, { cache: "no-cache" });
+  // Network-first with retry: attempt the fetch, retrying on transient network
+  // failures (Issue #67). This handles the common "first fetch fails, second
+  // works" scenario during Service Worker activation or on unstable mobile
+  // connections.
+  let res;
+  let lastError = null;
+  for (let attempt = 0; attempt <= FETCH_MAX_RETRIES; attempt++) {
+    try {
+      res = await fetch(u, { cache: "no-cache" });
+      lastError = null;
+      break;
+    } catch (e) {
+      lastError = e;
+      // If this wasn't our last attempt, wait before retrying (exponential backoff).
+      if (attempt < FETCH_MAX_RETRIES) {
+        const delay = FETCH_RETRY_DELAY_MS * Math.pow(2, attempt);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        continue;
+      }
+      throw e;
+    }
+  }
+
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
 
   const ce = (res.headers.get("content-encoding") ?? "").toLowerCase();

--- a/tests/fetch_retry_on_transient_failure_test.ts
+++ b/tests/fetch_retry_on_transient_failure_test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests that the fetchJson function retries on transient network failures.
+ *
+ * Issue #67: First fetch often fails but second works.
+ *
+ * Root cause: Transient network failures (e.g., during Service Worker
+ * activation, unstable connections, or mobile network handoffs) can cause the
+ * first fetch to fail. The user then has to manually retry, which succeeds.
+ *
+ * Fix: Implement automatic retry logic with exponential backoff for transient
+ * failures. This makes the app more resilient without requiring manual
+ * intervention.
+ *
+ * Created: 13-Jan-2026
+ */
+
+function assert(condition: unknown, message?: string): asserts condition {
+  if (!condition) throw new Error(message ?? "Assertion failed");
+}
+
+function repoPath(...parts: string[]): string {
+  const url = new URL(import.meta.url);
+  const here = url.pathname;
+  const root = here.replace(
+    /\/tests\/fetch_retry_on_transient_failure_test\.ts$/,
+    "",
+  );
+  return [root, ...parts].join("/");
+}
+
+Deno.test("app.js fetchJson includes retry logic for transient failures (Issue #67)", async () => {
+  const appPath = repoPath("docs", "app.js");
+  const js = await Deno.readTextFile(appPath);
+
+  // The fetchJson function should include retry logic to handle transient
+  // network failures that commonly cause "first fetch fails, second works"
+  // issues.
+  //
+  // We check for common retry patterns:
+  // - A loop with retry count (e.g., `while (retries < MAX_RETRIES)`)
+  // - Retry-related constants (e.g., MAX_RETRIES, maxRetries)
+  // - Exponential backoff delay
+  const hasRetryLoop = js.includes("retries") ||
+    js.includes("retry") ||
+    js.includes("attempt");
+
+  const hasMaxRetries = js.includes("MAX_RETRIES") ||
+    js.includes("maxRetries") ||
+    /retry.*<.*\d/.test(js) ||
+    /attempts?.*<.*\d/.test(js);
+
+  assert(
+    hasRetryLoop,
+    "Expected app.js to include retry logic for transient network failures. " +
+      "The 'first fetch fails, second works' issue (#67) can be mitigated by " +
+      "automatically retrying failed fetches.",
+  );
+
+  assert(
+    hasMaxRetries,
+    "Expected app.js to limit the number of retries to prevent infinite loops. " +
+      "Look for MAX_RETRIES, maxRetries, or a numeric limit on retry attempts.",
+  );
+});
+
+Deno.test("app.js retry logic includes backoff delay (Issue #67)", async () => {
+  const appPath = repoPath("docs", "app.js");
+  const js = await Deno.readTextFile(appPath);
+
+  // Retries should use a delay/backoff to avoid hammering the server.
+  // Look for patterns like:
+  // - await new Promise(resolve => setTimeout(resolve, delay))
+  // - delay * 2 (exponential backoff)
+  // - sleep(ms) or wait(ms) functions
+  const hasDelayBetweenRetries =
+    (js.includes("retry") || js.includes("retries") ||
+      js.includes("attempt")) &&
+    (js.includes("setTimeout") || js.includes("delay") ||
+      js.includes("backoff"));
+
+  assert(
+    hasDelayBetweenRetries,
+    "Expected app.js to include a delay between retries to implement " +
+      "exponential backoff. This prevents overwhelming the server and " +
+      "gives transient issues time to resolve.",
+  );
+});
+
+Deno.test("app.js retries only for network errors, not HTTP errors (Issue #67)", async () => {
+  const appPath = repoPath("docs", "app.js");
+  const js = await Deno.readTextFile(appPath);
+
+  // Retries should only happen for network-level failures (TypeError from
+  // fetch), not HTTP-level errors (4xx, 5xx responses). HTTP errors indicate
+  // the server explicitly responded, so retrying won't help.
+  //
+  // Look for logic that distinguishes between:
+  // - Network errors (caught in try/catch, e.g., "Failed to fetch")
+  // - HTTP errors (res.ok === false, e.g., 404, 500)
+
+  // Extract the fetchJson function body
+  const fetchJsonMatch = js.match(
+    /async\s+function\s+fetchJson\s*\([^)]*\)\s*\{[\s\S]*?^\}/m,
+  );
+
+  assert(
+    fetchJsonMatch,
+    "Expected to find fetchJson function in app.js",
+  );
+
+  const fetchJsonBody = fetchJsonMatch[0];
+
+  // The retry logic should be in the catch block (for network errors),
+  // not after checking res.ok (for HTTP errors).
+  const hasNetworkRetryLogic = fetchJsonBody.includes("catch") &&
+    (fetchJsonBody.includes("retry") ||
+      fetchJsonBody.includes("retries") ||
+      fetchJsonBody.includes("attempt"));
+
+  assert(
+    hasNetworkRetryLogic,
+    "Expected fetchJson to retry on network errors (caught exceptions) " +
+      "rather than HTTP errors (bad status codes). Network errors are " +
+      "transient and worth retrying; HTTP errors are authoritative.",
+  );
+});
+
+Deno.test("shared/snapshot_loader.js includes retry logic for transient failures (Issue #67)", async () => {
+  const loaderPath = repoPath("docs", "shared", "snapshot_loader.js");
+  const js = await Deno.readTextFile(loaderPath);
+
+  // The shared snapshot loader (used by graph/starfield views) should also
+  // have retry logic to handle transient network failures consistently.
+  const hasRetryConstants = js.includes("FETCH_MAX_RETRIES") &&
+    js.includes("FETCH_RETRY_DELAY_MS");
+
+  const hasRetryLoop = js.includes("attempt") &&
+    js.includes("FETCH_MAX_RETRIES");
+
+  const hasBackoff = js.includes("setTimeout") || js.includes("delay");
+
+  assert(
+    hasRetryConstants,
+    "Expected shared/snapshot_loader.js to define retry constants " +
+      "(FETCH_MAX_RETRIES, FETCH_RETRY_DELAY_MS).",
+  );
+
+  assert(
+    hasRetryLoop,
+    "Expected shared/snapshot_loader.js to include a retry loop with attempt counter.",
+  );
+
+  assert(
+    hasBackoff,
+    "Expected shared/snapshot_loader.js to include backoff delay between retries.",
+  );
+});


### PR DESCRIPTION
## Summary
Automated fix for issue #67

## Changes
This PR addresses the issue: **First fetch often fails but second works**

## Testing
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #67