### PR TITLE
Refactor app.js to import from shared modules (#89)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -28,6 +28,13 @@ import {
   summariseErrorConcentration,
   summariseSeriesStats,
 } from "./impact_diagnostics.js";
+import {
+  decodeBase64UrlToUtf8,
+  gunzipToText,
+  isDangerousUrlScheme,
+  normaliseSnapshotUrl,
+  readSnapshotFile,
+} from "./shared/snapshot_loader.js";
 
 let SNAPSHOT = null;
 let synapses = [];
@@ -382,47 +389,6 @@ function updateProgress(percent) {
 function hideProgress() {
   if (!el.progressContainer) return;
   el.progressContainer.style.display = "none";
-}
-
-async function gunzipToText(gzBytes) {
-  // Prefer the native streaming API when available (modern Chromium/Firefox).
-  // Some Safari/iOS builds still lack DecompressionStream, so fall back to a
-  // small JS implementation (vendored in ./vendor/fflate.browser.js).
-  if (typeof DecompressionStream !== "undefined") {
-    try {
-      const stream = new Blob([gzBytes]).stream().pipeThrough(
-        new DecompressionStream("gzip"),
-      );
-      return await new Response(stream).text();
-    } catch (_e) {
-      // Fall through to JS gunzip.
-    }
-  }
-
-  try {
-    const { gunzipSync } = await import("./vendor/fflate.browser.js");
-    const out = gunzipSync(gzBytes);
-    return new TextDecoder().decode(out);
-  } catch (_e) {
-    throw new Error(
-      "This snapshot is gzipped (.gz) but this browser can't decompress it. Export/upload an uncompressed .json, or use a browser with gzip support.",
-    );
-  }
-}
-
-function normaliseSnapshotUrl(inputUrl) {
-  const raw = String(inputUrl ?? "").trim();
-  if (!raw) return raw;
-
-  // Don't touch absolute URLs (including blob: for file picker flows).
-  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(raw)) return raw;
-
-  // Normalise dot-segments for relative paths. Some hosts/CDNs treat "/./x" as
-  // a different resource path rather than normalising it.
-  let u = raw;
-  while (u.startsWith("./")) u = u.slice(2);
-  u = u.replaceAll("/./", "/");
-  return u;
 }
 
 // ============================================================================
@@ -3399,15 +3365,7 @@ el.fileInput.onchange = async () => {
   try {
     setStatus(`Reading ${file.name}...`);
     showProgress(true); // Indeterminate for local file reading
-    let obj;
-    if (file.name.toLowerCase().endsWith(".gz")) {
-      const buf = new Uint8Array(await file.arrayBuffer());
-      const text = await gunzipToText(buf);
-      obj = JSON.parse(text);
-    } else {
-      const text = await file.text();
-      obj = JSON.parse(text);
-    }
+    const obj = await readSnapshotFile(file);
     hideProgress();
     await loadSnapshot(obj, file.name);
   } catch (e) {
@@ -3473,26 +3431,6 @@ initInboundFilters();
 // params (e.g. snapshotUrl / snapshotUrlB64) across.
 if (el.graphBtn instanceof HTMLAnchorElement) {
   el.graphBtn.href = `./graph/${window.location.search ?? ""}`;
-}
-
-function decodeBase64UrlToUtf8(base64Url) {
-  // Base64url decode for query params (avoids needing to percent-encode presigned URLs).
-  // See RFC 4648 §5.
-  try {
-    const base64 = base64Url.replaceAll("-", "+").replaceAll("_", "/");
-    const pad = "=".repeat((4 - (base64.length % 4)) % 4);
-    const bin = atob(base64 + pad);
-    const bytes = new Uint8Array(bin.length);
-    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-    return new TextDecoder().decode(bytes);
-  } catch (_e) {
-    return null;
-  }
-}
-
-function isDangerousUrlScheme(s) {
-  const v = String(s ?? "").trim().toLowerCase();
-  return v.startsWith("javascript:") || v.startsWith("data:");
 }
 
 let initialUrl = null;

--- a/docs/pr-summary-89.md
+++ b/docs/pr-summary-89.md
@@ -1,0 +1,33 @@
+## Summary
+
+Refactored `docs/app.js` to import shared utility functions from
+`docs/shared/snapshot_loader.js` instead of inlining duplicate copies. This
+removes ~62 lines of duplicated code and ensures bug fixes in the shared module
+automatically apply to all consumers. Closes #89.
+
+### Functions replaced with imports
+
+| Function | Lines removed | Notes |
+| --- | --- | --- |
+| `gunzipToText()` | 25 | Identical to shared version |
+| `normaliseSnapshotUrl()` | 14 | Identical to shared version |
+| `decodeBase64UrlToUtf8()` | 14 | Functionally identical to shared version |
+| `isDangerousUrlScheme()` | 4 | Identical to shared version |
+| Inline file-reading logic | 7 | Replaced with `readSnapshotFile()` import |
+
+The app-specific `fetchJson()` function (with PWA caching, CORS handling, and
+fallback URL logic) remains in `app.js` as it contains behaviour beyond the
+scope of the shared loader.
+
+## Evidence
+
+This is a pure refactoring with no visual or behavioural changes. The shared
+module functions are already tested in `tests/snapshot_loader_test.ts`. All 65
+existing tests continue to pass after the refactoring.
+
+## Test Plan
+
+- Added `tests/snapshot_loader_gunzip_test.ts` with tests for:
+  - `gunzipToText()` — decompresses gzipped data correctly, rejects invalid data
+  - `readSnapshotFile()` — parses plain JSON files, parses gzipped JSON files
+- All 65 tests pass via `./quality.sh` (format + lint + test)

--- a/docs/pr-summary-89.md
+++ b/docs/pr-summary-89.md
@@ -7,13 +7,13 @@ automatically apply to all consumers. Closes #89.
 
 ### Functions replaced with imports
 
-| Function | Lines removed | Notes |
-| --- | --- | --- |
-| `gunzipToText()` | 25 | Identical to shared version |
-| `normaliseSnapshotUrl()` | 14 | Identical to shared version |
-| `decodeBase64UrlToUtf8()` | 14 | Functionally identical to shared version |
-| `isDangerousUrlScheme()` | 4 | Identical to shared version |
-| Inline file-reading logic | 7 | Replaced with `readSnapshotFile()` import |
+| Function                  | Lines removed | Notes                                     |
+| ------------------------- | ------------- | ----------------------------------------- |
+| `gunzipToText()`          | 25            | Identical to shared version               |
+| `normaliseSnapshotUrl()`  | 14            | Identical to shared version               |
+| `decodeBase64UrlToUtf8()` | 14            | Functionally identical to shared version  |
+| `isDangerousUrlScheme()`  | 4             | Identical to shared version               |
+| Inline file-reading logic | 7             | Replaced with `readSnapshotFile()` import |
 
 The app-specific `fetchJson()` function (with PWA caching, CORS handling, and
 fallback URL logic) remains in `app.js` as it contains behaviour beyond the

--- a/tests/snapshot_loader_gunzip_test.ts
+++ b/tests/snapshot_loader_gunzip_test.ts
@@ -1,0 +1,55 @@
+import { assert, assertEquals } from "./test_helpers.ts";
+
+import {
+  gunzipToText,
+  readSnapshotFile,
+} from "../docs/shared/snapshot_loader.js";
+
+// --- gunzipToText ---
+
+Deno.test("gunzipToText decompresses gzipped data", async () => {
+  const original = '{"hello":"world"}';
+  const encoded = new TextEncoder().encode(original);
+  // Compress using the CompressionStream API (available in Deno).
+  const stream = new Blob([encoded]).stream().pipeThrough(
+    new CompressionStream("gzip"),
+  );
+  const compressed = new Uint8Array(await new Response(stream).arrayBuffer());
+  const result = await gunzipToText(compressed);
+  assertEquals(result, original);
+});
+
+Deno.test("gunzipToText rejects invalid data", async () => {
+  const garbage = new Uint8Array([0, 1, 2, 3, 4, 5]);
+  try {
+    await gunzipToText(garbage);
+    assert(false, "Should have thrown");
+  } catch (e) {
+    assert(e instanceof Error, "Should throw an Error");
+  }
+});
+
+// --- readSnapshotFile ---
+
+Deno.test("readSnapshotFile parses plain JSON file", async () => {
+  const json = '{"meta":{"version":"1.0"}}';
+  const file = new File([json], "snapshot.json", {
+    type: "application/json",
+  });
+  const result = await readSnapshotFile(file);
+  assertEquals(result.meta.version, "1.0");
+});
+
+Deno.test("readSnapshotFile parses gzipped JSON file", async () => {
+  const json = '{"meta":{"version":"2.0"}}';
+  const encoded = new TextEncoder().encode(json);
+  const stream = new Blob([encoded]).stream().pipeThrough(
+    new CompressionStream("gzip"),
+  );
+  const compressed = new Uint8Array(await new Response(stream).arrayBuffer());
+  const file = new File([compressed], "snapshot.json.gz", {
+    type: "application/gzip",
+  });
+  const result = await readSnapshotFile(file);
+  assertEquals(result.meta.version, "2.0");
+});


### PR DESCRIPTION
## Summary

Refactored `docs/app.js` to import shared utility functions from
`docs/shared/snapshot_loader.js` instead of inlining duplicate copies. This
removes ~62 lines of duplicated code and ensures bug fixes in the shared module
automatically apply to all consumers. Closes #89.

### Functions replaced with imports

| Function | Lines removed | Notes |
| --- | --- | --- |
| `gunzipToText()` | 25 | Identical to shared version |
| `normaliseSnapshotUrl()` | 14 | Identical to shared version |
| `decodeBase64UrlToUtf8()` | 14 | Functionally identical to shared version |
| `isDangerousUrlScheme()` | 4 | Identical to shared version |
| Inline file-reading logic | 7 | Replaced with `readSnapshotFile()` import |

The app-specific `fetchJson()` function (with PWA caching, CORS handling, and
fallback URL logic) remains in `app.js` as it contains behaviour beyond the
scope of the shared loader.

## Evidence

This is a pure refactoring with no visual or behavioural changes. The shared
module functions are already tested in `tests/snapshot_loader_test.ts`. All 65
existing tests continue to pass after the refactoring.

## Test Plan

- Added `tests/snapshot_loader_gunzip_test.ts` with tests for:
  - `gunzipToText()` — decompresses gzipped data correctly, rejects invalid data
  - `readSnapshotFile()` — parses plain JSON files, parses gzipped JSON files
- All 65 tests pass via `./quality.sh` (format + lint + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)