### PR TITLE
Add test_helpers tests and replace manual tolerance checks (#90)

### DIFF
--- a/docs/pr-summary-90.md
+++ b/docs/pr-summary-90.md
@@ -1,0 +1,29 @@
+## Summary
+
+Add tests for shared test assertion helpers and replace remaining manual
+tolerance checks with `approx()`. Closes #90.
+
+The shared `tests/test_helpers.ts` module (with `assert`, `assertEquals`, and
+`approx`) was already extracted and adopted by all 8 test files. This PR
+completes the effort by:
+
+1. Adding comprehensive tests for the helpers themselves
+   (`tests/test_helpers_test.ts`) — verifying truthy/falsy behaviour, equality
+   semantics, tolerance boundaries, custom tolerances, and error messages.
+2. Replacing 4 remaining manual `Math.abs(...)` tolerance checks in
+   `impact_attribution_test.ts` with the shared `approx()` helper, eliminating
+   the last pocket of duplicated assertion logic.
+
+## Evidence
+
+This is a purely backend/test change with no visual output. All 77 tests pass
+and the full quality gate (`./quality.sh`) completes cleanly.
+
+## Test Plan
+
+- Added `tests/test_helpers_test.ts` with 12 tests covering `assert`,
+  `assertEquals`, and `approx` (pass/fail paths, default/custom messages,
+  default/custom tolerances)
+- Updated `tests/impact_attribution_test.ts` to use `approx()` instead of
+  manual `Math.abs` comparisons (no behaviour change, same tolerance)
+- Full suite: 77 tests pass, 0 failures

--- a/docs/pr-summary-90.md
+++ b/docs/pr-summary-90.md
@@ -24,6 +24,6 @@ and the full quality gate (`./quality.sh`) completes cleanly.
 - Added `tests/test_helpers_test.ts` with 12 tests covering `assert`,
   `assertEquals`, and `approx` (pass/fail paths, default/custom messages,
   default/custom tolerances)
-- Updated `tests/impact_attribution_test.ts` to use `approx()` instead of
-  manual `Math.abs` comparisons (no behaviour change, same tolerance)
+- Updated `tests/impact_attribution_test.ts` to use `approx()` instead of manual
+  `Math.abs` comparisons (no behaviour change, same tolerance)
 - Full suite: 77 tests pass, 0 failures

--- a/tests/impact_attribution_test.ts
+++ b/tests/impact_attribution_test.ts
@@ -44,17 +44,21 @@ Deno.test("computeImpactBreakdownToOutputs splits impact across outputs and path
 
   // Shares may have tiny floating error; check within tolerance.
   const tol = 1e-12;
-  assert(
-    Math.abs(out0.share - 0.5) < tol,
+  approx(
+    out0.share,
+    0.5,
+    tol,
     `Expected output-0 share ~0.5, got ${out0.share}`,
   );
-  assert(
-    Math.abs(out1.share - 0.5) < tol,
+  approx(
+    out1.share,
+    0.5,
+    tol,
     `Expected output-1 share ~0.5, got ${out1.share}`,
   );
 
-  assert(Math.abs((out0.allocatedImpact ?? 0) - 0.1) < tol);
-  assert(Math.abs((out1.allocatedImpact ?? 0) - 0.1) < tol);
+  approx(out0.allocatedImpact ?? 0, 0.1, tol);
+  approx(out1.allocatedImpact ?? 0, 0.1, tol);
 
   // Ensure both distinct output-0 paths are present.
   const out0Paths = new Set(out0.topPaths.map((p) => p.nodes.join("→")));

--- a/tests/test_helpers_test.ts
+++ b/tests/test_helpers_test.ts
@@ -1,0 +1,141 @@
+import { approx, assert, assertEquals } from "./test_helpers.ts";
+
+// --- assert ---
+
+Deno.test("assert passes for truthy values", () => {
+  assert(true);
+  assert(1);
+  assert("non-empty");
+  assert({});
+  assert([]);
+});
+
+Deno.test("assert throws for falsy values", () => {
+  let threw = false;
+  try {
+    assert(false, "should throw");
+  } catch (e) {
+    threw = true;
+    assert((e as Error).message === "should throw");
+  }
+  if (!threw) throw new Error("Expected assert(false) to throw");
+});
+
+Deno.test("assert throws with default message when none provided", () => {
+  let threw = false;
+  try {
+    assert(false);
+  } catch (e) {
+    threw = true;
+    assert((e as Error).message === "Assertion failed");
+  }
+  if (!threw) throw new Error("Expected assert(false) to throw");
+});
+
+// --- assertEquals ---
+
+Deno.test("assertEquals passes for strictly equal values", () => {
+  assertEquals(42, 42);
+  assertEquals("hello", "hello");
+  assertEquals(true, true);
+  assertEquals(null, null);
+  assertEquals(undefined, undefined);
+});
+
+Deno.test("assertEquals throws for non-equal values", () => {
+  let threw = false;
+  try {
+    assertEquals(1, 2, "mismatch");
+  } catch (e) {
+    threw = true;
+    assert((e as Error).message === "mismatch");
+  }
+  if (!threw) throw new Error("Expected assertEquals(1, 2) to throw");
+});
+
+Deno.test("assertEquals throws with descriptive default message", () => {
+  let threw = false;
+  try {
+    assertEquals("a", "b");
+  } catch (e) {
+    threw = true;
+    const msg = (e as Error).message;
+    assert(
+      msg.includes('"a"') && msg.includes('"b"'),
+      `Expected message to include both values, got: ${msg}`,
+    );
+  }
+  if (!threw) throw new Error("Expected assertEquals to throw");
+});
+
+// --- approx ---
+
+Deno.test("approx passes for equal values", () => {
+  approx(1.0, 1.0);
+});
+
+Deno.test("approx passes within default tolerance (1e-9)", () => {
+  approx(1.0, 1.0 + 1e-10);
+});
+
+Deno.test("approx fails outside default tolerance (1e-9)", () => {
+  let threw = false;
+  try {
+    approx(1.0, 1.0 + 1e-8);
+  } catch {
+    threw = true;
+  }
+  if (!threw) {
+    throw new Error(
+      "Expected approx to throw for values outside 1e-9 tolerance",
+    );
+  }
+});
+
+Deno.test("approx respects custom tolerance", () => {
+  // Should pass with tolerance of 0.1
+  approx(1.0, 1.05, 0.1);
+
+  // Should fail with tolerance of 0.01
+  let threw = false;
+  try {
+    approx(1.0, 1.05, 0.01);
+  } catch {
+    threw = true;
+  }
+  if (!threw) {
+    throw new Error(
+      "Expected approx to throw for values outside custom tolerance",
+    );
+  }
+});
+
+Deno.test("approx includes expected and actual in error message", () => {
+  let threw = false;
+  try {
+    approx(5.0, 10.0);
+  } catch (e) {
+    threw = true;
+    const msg = (e as Error).message;
+    assert(
+      msg.includes("10"),
+      `Expected message to include expected value, got: ${msg}`,
+    );
+    assert(
+      msg.includes("5"),
+      `Expected message to include actual value, got: ${msg}`,
+    );
+  }
+  if (!threw) throw new Error("Expected approx to throw");
+});
+
+Deno.test("approx uses custom message when provided", () => {
+  let threw = false;
+  try {
+    approx(0, 100, 1e-9, "custom error");
+  } catch (e) {
+    threw = true;
+    assert((e as Error).message === "custom error");
+  }
+  if (!threw) throw new Error("Expected approx to throw");
+});


### PR DESCRIPTION
## Summary

Add tests for shared test assertion helpers and replace remaining manual
tolerance checks with `approx()`. Closes #90.

The shared `tests/test_helpers.ts` module (with `assert`, `assertEquals`, and
`approx`) was already extracted and adopted by all 8 test files. This PR
completes the effort by:

1. Adding comprehensive tests for the helpers themselves
   (`tests/test_helpers_test.ts`) — verifying truthy/falsy behaviour, equality
   semantics, tolerance boundaries, custom tolerances, and error messages.
2. Replacing 4 remaining manual `Math.abs(...)` tolerance checks in
   `impact_attribution_test.ts` with the shared `approx()` helper, eliminating
   the last pocket of duplicated assertion logic.

## Evidence

This is a purely backend/test change with no visual output. All 77 tests pass
and the full quality gate (`./quality.sh`) completes cleanly.

## Test Plan

- Added `tests/test_helpers_test.ts` with 12 tests covering `assert`,
  `assertEquals`, and `approx` (pass/fail paths, default/custom messages,
  default/custom tolerances)
- Updated `tests/impact_attribution_test.ts` to use `approx()` instead of
  manual `Math.abs` comparisons (no behaviour change, same tolerance)
- Full suite: 77 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)