### PR TITLE
Add lint coverage regression tests for shared modules (#91)

### DIFF
--- a/docs/pr-summary-91.md
+++ b/docs/pr-summary-91.md
@@ -1,0 +1,36 @@
+## Summary
+
+The `deno.json` lint exclusion was already narrowed from the blanket `docs/**`
+to targeted exclusions for DOM-dependent files only (done in commit d8b7342 as
+part of PR #94). This PR adds regression tests that verify the shared DOM-free
+modules remain covered by `deno lint`, preventing accidental re-widening of the
+exclusion in the future. Closes #91.
+
+## Evidence
+
+No UI changes. The quality gate passes cleanly:
+
+```
+==> Format (check)
+Checked 42 files
+
+==> Lint
+Checked 19 files
+
+==> Tests
+ok | 83 passed | 0 failed
+```
+
+The 5 DOM-free modules are confirmed to be linted:
+- `docs/shared/graph_analysis.js`
+- `docs/shared/snapshot_loader.js`
+- `docs/shared/colour_maps.js`
+- `docs/impact_attribution.js`
+- `docs/impact_diagnostics.js`
+
+## Test Plan
+
+Added `tests/lint_coverage_test.ts` with 6 new tests:
+- 3 tests verifying each shared module (`graph_analysis.js`, `snapshot_loader.js`, `colour_maps.js`) is checked by `deno lint`
+- 2 tests verifying `impact_attribution.js` and `impact_diagnostics.js` are checked by `deno lint`
+- 1 test verifying the `deno.json` lint configuration excludes DOM-dependent files but not shared modules

--- a/docs/pr-summary-91.md
+++ b/docs/pr-summary-91.md
@@ -22,6 +22,7 @@ ok | 83 passed | 0 failed
 ```
 
 The 5 DOM-free modules are confirmed to be linted:
+
 - `docs/shared/graph_analysis.js`
 - `docs/shared/snapshot_loader.js`
 - `docs/shared/colour_maps.js`
@@ -31,6 +32,10 @@ The 5 DOM-free modules are confirmed to be linted:
 ## Test Plan
 
 Added `tests/lint_coverage_test.ts` with 6 new tests:
-- 3 tests verifying each shared module (`graph_analysis.js`, `snapshot_loader.js`, `colour_maps.js`) is checked by `deno lint`
-- 2 tests verifying `impact_attribution.js` and `impact_diagnostics.js` are checked by `deno lint`
-- 1 test verifying the `deno.json` lint configuration excludes DOM-dependent files but not shared modules
+
+- 3 tests verifying each shared module (`graph_analysis.js`,
+  `snapshot_loader.js`, `colour_maps.js`) is checked by `deno lint`
+- 2 tests verifying `impact_attribution.js` and `impact_diagnostics.js` are
+  checked by `deno lint`
+- 1 test verifying the `deno.json` lint configuration excludes DOM-dependent
+  files but not shared modules

--- a/tests/lint_coverage_test.ts
+++ b/tests/lint_coverage_test.ts
@@ -1,0 +1,102 @@
+import { assert, assertEquals } from "./test_helpers.ts";
+
+/**
+ * Verifies that DOM-free shared modules are covered by `deno lint`.
+ *
+ * If the deno.json lint exclusions are accidentally widened back to
+ * "docs/**", these tests will fail because `deno lint` will skip the
+ * shared modules entirely (exit-code 0 but "Checked 0 files").
+ */
+
+function repoRoot(): string {
+  const url = new URL(import.meta.url);
+  return url.pathname.replace(/\/tests\/lint_coverage_test\.ts$/, "");
+}
+
+/** Run `deno lint` on a single file and return the result. */
+async function lintFile(
+  relativePath: string,
+): Promise<{ success: boolean; stdout: string; stderr: string }> {
+  const fullPath = `${repoRoot()}/${relativePath}`;
+  const cmd = new Deno.Command("deno", {
+    args: ["lint", fullPath],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const out = await cmd.output();
+  return {
+    success: out.success,
+    stdout: new TextDecoder().decode(out.stdout),
+    stderr: new TextDecoder().decode(out.stderr),
+  };
+}
+
+const SHARED_MODULES = [
+  "docs/shared/graph_analysis.js",
+  "docs/shared/snapshot_loader.js",
+  "docs/shared/colour_maps.js",
+];
+
+for (const mod of SHARED_MODULES) {
+  const name = mod.split("/").pop()!;
+  Deno.test(`deno lint covers shared module: ${name}`, async () => {
+    const result = await lintFile(mod);
+    assert(
+      result.success,
+      `deno lint failed for ${mod}:\n${result.stderr}`,
+    );
+    // Verify the file was actually checked (not silently skipped)
+    assert(
+      result.stderr.includes("Checked 1 file"),
+      `Expected deno lint to check ${mod} but output was:\n${result.stderr}`,
+    );
+  });
+}
+
+Deno.test("deno lint covers impact_attribution.js", async () => {
+  const result = await lintFile("docs/impact_attribution.js");
+  assert(result.success, `deno lint failed:\n${result.stderr}`);
+  assert(
+    result.stderr.includes("Checked 1 file"),
+    `Expected deno lint to check impact_attribution.js but output was:\n${result.stderr}`,
+  );
+});
+
+Deno.test("deno lint covers impact_diagnostics.js", async () => {
+  const result = await lintFile("docs/impact_diagnostics.js");
+  assert(result.success, `deno lint failed:\n${result.stderr}`);
+  assert(
+    result.stderr.includes("Checked 1 file"),
+    `Expected deno lint to check impact_diagnostics.js but output was:\n${result.stderr}`,
+  );
+});
+
+Deno.test("deno lint configuration excludes DOM-dependent files", async () => {
+  const root = repoRoot();
+  const configText = await Deno.readTextFile(`${root}/deno.json`);
+  const config = JSON.parse(configText);
+  const excludes: string[] = config?.lint?.exclude ?? [];
+
+  // Shared DOM-free modules must NOT appear in the exclusion list
+  for (const mod of SHARED_MODULES) {
+    assertEquals(
+      excludes.includes(mod),
+      false,
+      `${mod} should not be in lint.exclude`,
+    );
+  }
+
+  // DOM-dependent files SHOULD be excluded
+  const expectedExclusions = [
+    "docs/app.js",
+    "docs/sw.js",
+    "docs/shared/theme.js",
+  ];
+  for (const exc of expectedExclusions) {
+    assertEquals(
+      excludes.includes(exc),
+      true,
+      `${exc} should be in lint.exclude (DOM-dependent)`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

The `deno.json` lint exclusion was already narrowed from the blanket `docs/**`
to targeted exclusions for DOM-dependent files only (done in commit d8b7342 as
part of PR #94). This PR adds regression tests that verify the shared DOM-free
modules remain covered by `deno lint`, preventing accidental re-widening of the
exclusion in the future. Closes #91.

## Evidence

No UI changes. The quality gate passes cleanly:

```
==> Format (check)
Checked 42 files

==> Lint
Checked 19 files

==> Tests
ok | 83 passed | 0 failed
```

The 5 DOM-free modules are confirmed to be linted:
- `docs/shared/graph_analysis.js`
- `docs/shared/snapshot_loader.js`
- `docs/shared/colour_maps.js`
- `docs/impact_attribution.js`
- `docs/impact_diagnostics.js`

## Test Plan

Added `tests/lint_coverage_test.ts` with 6 new tests:
- 3 tests verifying each shared module (`graph_analysis.js`, `snapshot_loader.js`, `colour_maps.js`) is checked by `deno lint`
- 2 tests verifying `impact_attribution.js` and `impact_diagnostics.js` are checked by `deno lint`
- 1 test verifying the `deno.json` lint configuration excludes DOM-dependent files but not shared modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)