### PR TITLE
Extract snapshot URL constants to shared config module (#93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Only pure, DOM-free modules can be tested in Deno:
 | -------------------------------- | ------------------------------------------------------------------------------ |
 | `docs/impact_attribution.js`     | `computeImpactBreakdownToOutputs`, `computeInboundSynapseImpactAllocation`     |
 | `docs/impact_diagnostics.js`     | `squashDerivative`, `computeGradientProxyImpact`, `summariseSeriesStats`, etc. |
+| `docs/shared/config.js`          | `DEFAULT_SNAPSHOT_URL`, `SNAPSHOT_FALLBACK_URLS`                               |
 | `docs/shared/graph_analysis.js`  | `buildGraphIndex`, `computeReachableToOutputs`, `computeTopContributingInputs` |
 | `docs/shared/snapshot_loader.js` | `normaliseSnapshotUrl`, `decodeBase64UrlToUtf8`, `isDangerousUrlScheme`        |
 | `docs/shared/colour_maps.js`     | `hash32`, `u01ToSigned`, `u32ToU01`, `neuronColourRgb01`                       |

--- a/docs/app.js
+++ b/docs/app.js
@@ -35,6 +35,10 @@ import {
   normaliseSnapshotUrl,
   readSnapshotFile,
 } from "./shared/snapshot_loader.js";
+import {
+  DEFAULT_SNAPSHOT_URL,
+  SNAPSHOT_FALLBACK_URLS,
+} from "./shared/config.js";
 
 let SNAPSHOT = null;
 let synapses = [];
@@ -73,29 +77,6 @@ let INPUT_DASH = {
   inputCount: 0,
   rows: [], // { uuid, alias, description, reachable, outDegree, proxy, constant, candidates }
 };
-
-// Default snapshot used when the app is opened without a URL parameter.
-//
-// We now host the snapshot in a dedicated repo (`NEAT-AI-Snapshot`) published via
-// GitHub Pages. This keeps the Explore repo program-only and avoids churn from
-// committing large binary snapshot artefacts.
-//
-// Offline behaviour:
-// - When online, we try to fetch the latest snapshot and cache it.
-// - When offline, we fall back to cached snapshots (Cache Storage).
-//
-// Note: avoid a leading "./" because some static hosts treat "/./file" as a
-// distinct path (and may 404) rather than normalising it.
-const DEFAULT_SNAPSHOT_URL =
-  "https://stsoftwareau.github.io/NEAT-AI-Snapshot/snapshot.json.gz";
-
-// Fallbacks used when GitHub Pages is blocked by CORS on some networks.
-// `raw.githubusercontent.com` typically ships permissive CORS headers.
-const SNAPSHOT_FALLBACK_URLS = [
-  "https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI-Snapshot/Develop/docs/snapshot.json.gz",
-  "https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI-Snapshot/main/docs/snapshot.json.gz",
-  "snapshot.json.gz", // last resort: same-origin (if present)
-];
 
 // Thresholds for highlighting
 const IMPACT_HIGHLIGHT_THRESHOLD = 0.1; // Highlight if impact > 0.1

--- a/docs/graph/graph.js
+++ b/docs/graph/graph.js
@@ -19,9 +19,10 @@ import {
 } from "../shared/snapshot_loader.js";
 import { hash32, neuronColourRgb01, u32ToU01 } from "../shared/colour_maps.js";
 import { computeInboundSynapseImpactAllocation } from "../impact_attribution.js";
-
-const DEFAULT_SNAPSHOT_URL =
-  "https://stsoftwareau.github.io/NEAT-AI-Snapshot/snapshot.json.gz";
+import {
+  DEFAULT_SNAPSHOT_URL,
+  SNAPSHOT_FALLBACK_URLS,
+} from "../shared/config.js";
 
 // Starfield layout settings (tune for intuition > mathematical correctness).
 const FOCUS_MAX_DEPTH = 5;
@@ -3233,18 +3234,40 @@ function buildHudForIndex(idx) {
 async function loadSnapshotFromUrl(url) {
   setStatus(`Loading ${url}...`);
   showProgress(true);
-  const obj = await fetchSnapshotJson(url, {
-    onProgress: (p) => {
-      if (!p.totalBytes) {
-        showProgress(true);
-        return;
+
+  /** @type {(p: {totalBytes: number|null, receivedBytes: number}) => void} */
+  const onProgress = (p) => {
+    if (!p.totalBytes) {
+      showProgress(true);
+      return;
+    }
+    showProgress(false);
+    updateProgress((p.receivedBytes / p.totalBytes) * 100);
+  };
+
+  try {
+    const obj = await fetchSnapshotJson(url, { onProgress });
+    hideProgress();
+    return obj;
+  } catch (e) {
+    // Try fallback URLs when loading the default snapshot fails (Issue #93).
+    // GitHub Pages can be blocked by CORS on some networks.
+    if (String(url) === DEFAULT_SNAPSHOT_URL) {
+      for (const fallback of SNAPSHOT_FALLBACK_URLS) {
+        if (!fallback || fallback === url) continue;
+        try {
+          setStatus(`Trying fallback ${fallback}...`);
+          const obj = await fetchSnapshotJson(fallback, { onProgress });
+          hideProgress();
+          return obj;
+        } catch (_e2) {
+          // Keep trying next fallback.
+        }
       }
-      showProgress(false);
-      updateProgress((p.receivedBytes / p.totalBytes) * 100);
-    },
-  });
-  hideProgress();
-  return obj;
+    }
+    hideProgress();
+    throw e;
+  }
 }
 
 async function loadSnapshot(source, label) {

--- a/docs/pr-summary-93.md
+++ b/docs/pr-summary-93.md
@@ -21,7 +21,8 @@ Closes #93.
 
 ## Evidence
 
-This is a non-UI refactoring change (no visual changes). All quality checks pass:
+This is a non-UI refactoring change (no visual changes). All quality checks
+pass:
 
 - Format: 47 files checked
 - Lint: 22 files checked

--- a/docs/pr-summary-93.md
+++ b/docs/pr-summary-93.md
@@ -1,0 +1,39 @@
+## Summary
+
+Extract `DEFAULT_SNAPSHOT_URL` and `SNAPSHOT_FALLBACK_URLS` into a shared config
+module (`docs/shared/config.js`) and import from both `app.js` and `graph.js`.
+Add fallback URL support to the graph explorer so it has the same resilient
+loading behaviour as the trace explorer when GitHub Pages is blocked by CORS.
+Closes #93.
+
+## Changes
+
+- **New**: `docs/shared/config.js` — single source of truth for snapshot URL
+  constants (DOM-free, lintable, testable)
+- **Updated**: `docs/app.js` — imports `DEFAULT_SNAPSHOT_URL` and
+  `SNAPSHOT_FALLBACK_URLS` from shared config instead of defining them inline
+- **Updated**: `docs/graph/graph.js` — imports from shared config and adds
+  fallback URL logic to `loadSnapshotFromUrl` (mirrors `app.js` behaviour)
+- **Updated**: `tests/lint_coverage_test.ts` — includes `config.js` in shared
+  module lint coverage
+- **Updated**: `README.md` — adds `docs/shared/config.js` to the testable
+  modules table
+
+## Evidence
+
+This is a non-UI refactoring change (no visual changes). All quality checks pass:
+
+- Format: 47 files checked
+- Lint: 22 files checked
+- Tests: 107 passed, 0 failed
+
+## Test Plan
+
+- Added `tests/config_test.ts` with 8 tests verifying:
+  - `DEFAULT_SNAPSHOT_URL` is a valid HTTPS URL pointing to the snapshot repo
+  - `SNAPSHOT_FALLBACK_URLS` is a non-empty array of strings
+  - Fallback list does not redundantly include the default URL
+  - At least one `raw.githubusercontent.com` fallback exists
+  - At least one same-origin (relative path) fallback exists
+- Updated `tests/lint_coverage_test.ts` to verify `config.js` is covered by
+  `deno lint`

--- a/docs/shared/config.js
+++ b/docs/shared/config.js
@@ -1,0 +1,32 @@
+/**
+ * Shared snapshot configuration (Issue #93).
+ *
+ * Single source of truth for the default snapshot URL and fallback URLs.
+ * Imported by both the trace explorer (app.js) and the graph explorer
+ * (graph/graph.js) to ensure consistent behaviour.
+ *
+ * This module is DOM-free and testable under Deno.
+ */
+
+/**
+ * Default snapshot used when the app is opened without a URL parameter.
+ *
+ * Hosted in a dedicated repo (`NEAT-AI-Snapshot`) published via GitHub Pages.
+ * This keeps the Explore repo program-only and avoids churn from committing
+ * large binary snapshot artefacts.
+ *
+ * Note: avoid a leading "./" because some static hosts treat "/./file" as a
+ * distinct path (and may 404) rather than normalising it.
+ */
+export const DEFAULT_SNAPSHOT_URL =
+  "https://stsoftwareau.github.io/NEAT-AI-Snapshot/snapshot.json.gz";
+
+/**
+ * Fallbacks used when GitHub Pages is blocked by CORS on some networks.
+ * `raw.githubusercontent.com` typically ships permissive CORS headers.
+ */
+export const SNAPSHOT_FALLBACK_URLS = [
+  "https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI-Snapshot/Develop/docs/snapshot.json.gz",
+  "https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI-Snapshot/main/docs/snapshot.json.gz",
+  "snapshot.json.gz", // last resort: same-origin (if present)
+];

--- a/tests/config_test.ts
+++ b/tests/config_test.ts
@@ -1,0 +1,71 @@
+import { assert, assertEquals } from "./test_helpers.ts";
+
+import {
+  DEFAULT_SNAPSHOT_URL,
+  SNAPSHOT_FALLBACK_URLS,
+} from "../docs/shared/config.js";
+
+// --- DEFAULT_SNAPSHOT_URL ---
+
+Deno.test("DEFAULT_SNAPSHOT_URL is a valid HTTPS URL", () => {
+  assert(
+    DEFAULT_SNAPSHOT_URL.startsWith("https://"),
+    "Expected DEFAULT_SNAPSHOT_URL to start with https://",
+  );
+});
+
+Deno.test("DEFAULT_SNAPSHOT_URL points to the snapshot repo", () => {
+  assert(
+    DEFAULT_SNAPSHOT_URL.includes("NEAT-AI-Snapshot"),
+    "Expected DEFAULT_SNAPSHOT_URL to reference the NEAT-AI-Snapshot repo",
+  );
+});
+
+Deno.test("DEFAULT_SNAPSHOT_URL ends with snapshot.json.gz", () => {
+  assert(
+    DEFAULT_SNAPSHOT_URL.endsWith("snapshot.json.gz"),
+    "Expected DEFAULT_SNAPSHOT_URL to end with snapshot.json.gz",
+  );
+});
+
+// --- SNAPSHOT_FALLBACK_URLS ---
+
+Deno.test("SNAPSHOT_FALLBACK_URLS is a non-empty array", () => {
+  assert(Array.isArray(SNAPSHOT_FALLBACK_URLS), "Expected an array");
+  assert(SNAPSHOT_FALLBACK_URLS.length > 0, "Expected at least one fallback");
+});
+
+Deno.test("SNAPSHOT_FALLBACK_URLS does not include DEFAULT_SNAPSHOT_URL", () => {
+  assertEquals(
+    SNAPSHOT_FALLBACK_URLS.includes(DEFAULT_SNAPSHOT_URL),
+    false,
+    "Fallback list should not include the default URL (it would be redundant)",
+  );
+});
+
+Deno.test("SNAPSHOT_FALLBACK_URLS entries are all strings", () => {
+  for (const url of SNAPSHOT_FALLBACK_URLS) {
+    assertEquals(typeof url, "string", "Each fallback URL must be a string");
+    assert(url.length > 0, "Fallback URLs must not be empty strings");
+  }
+});
+
+Deno.test("SNAPSHOT_FALLBACK_URLS includes a raw.githubusercontent.com entry", () => {
+  const hasRawGh = SNAPSHOT_FALLBACK_URLS.some((u: string) =>
+    u.includes("raw.githubusercontent.com")
+  );
+  assert(
+    hasRawGh,
+    "Expected at least one fallback using raw.githubusercontent.com",
+  );
+});
+
+Deno.test("SNAPSHOT_FALLBACK_URLS includes a same-origin fallback", () => {
+  const hasSameOrigin = SNAPSHOT_FALLBACK_URLS.some((u: string) =>
+    !u.startsWith("http")
+  );
+  assert(
+    hasSameOrigin,
+    "Expected at least one same-origin (relative path) fallback",
+  );
+});

--- a/tests/lint_coverage_test.ts
+++ b/tests/lint_coverage_test.ts
@@ -32,6 +32,7 @@ async function lintFile(
 }
 
 const SHARED_MODULES = [
+  "docs/shared/config.js",
   "docs/shared/graph_analysis.js",
   "docs/shared/snapshot_loader.js",
   "docs/shared/colour_maps.js",


### PR DESCRIPTION
## Summary

Extract `DEFAULT_SNAPSHOT_URL` and `SNAPSHOT_FALLBACK_URLS` into a shared config
module (`docs/shared/config.js`) and import from both `app.js` and `graph.js`.
Add fallback URL support to the graph explorer so it has the same resilient
loading behaviour as the trace explorer when GitHub Pages is blocked by CORS.
Closes #93.

## Changes

- **New**: `docs/shared/config.js` — single source of truth for snapshot URL
  constants (DOM-free, lintable, testable)
- **Updated**: `docs/app.js` — imports `DEFAULT_SNAPSHOT_URL` and
  `SNAPSHOT_FALLBACK_URLS` from shared config instead of defining them inline
- **Updated**: `docs/graph/graph.js` — imports from shared config and adds
  fallback URL logic to `loadSnapshotFromUrl` (mirrors `app.js` behaviour)
- **Updated**: `tests/lint_coverage_test.ts` — includes `config.js` in shared
  module lint coverage
- **Updated**: `README.md` — adds `docs/shared/config.js` to the testable
  modules table

## Evidence

This is a non-UI refactoring change (no visual changes). All quality checks pass:

- Format: 47 files checked
- Lint: 22 files checked
- Tests: 107 passed, 0 failed

## Test Plan

- Added `tests/config_test.ts` with 8 tests verifying:
  - `DEFAULT_SNAPSHOT_URL` is a valid HTTPS URL pointing to the snapshot repo
  - `SNAPSHOT_FALLBACK_URLS` is a non-empty array of strings
  - Fallback list does not redundantly include the default URL
  - At least one `raw.githubusercontent.com` fallback exists
  - At least one same-origin (relative path) fallback exists
- Updated `tests/lint_coverage_test.ts` to verify `config.js` is covered by
  `deno lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)