### PR TITLE
Fix silent loading failures with visible error handling (#126)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -3929,7 +3929,10 @@ if (el.overviewExploreBtn) {
 el.fetchBtn.onclick = () => {
   const raw = el.fetchUrl.value.trim() || DEFAULT_SNAPSHOT_URL;
   const url = normaliseSnapshotUrl(raw);
-  loadSnapshot(url, url);
+  loadSnapshot(url, url).catch((e) => {
+    console.error("Manual fetch failed:", e);
+    setStatus(`Fetch failed: ${e?.message ?? e}`, "bad");
+  });
 };
 
 el.fileBtn.onclick = () => el.fileInput.click();
@@ -4041,11 +4044,21 @@ async function autoLoadWithRetry(url, label) {
   }
 }
 
+// Mark that app.js loaded so the global error handler in index.html
+// stops overriding the status bar (Issue #126).
+if (el.status) el.status.dataset.appLoaded = "1";
+
 if (initialUrl) {
   el.fetchUrl.value = initialUrl;
-  autoLoadWithRetry(initialUrl, initialLabel ?? initialUrl);
+  autoLoadWithRetry(initialUrl, initialLabel ?? initialUrl).catch((e) => {
+    console.error("Auto-load failed:", e);
+    setStatus(`Load failed: ${e?.message ?? e}`, "bad");
+  });
 } else {
   el.fetchUrl.value = DEFAULT_SNAPSHOT_URL;
-  setStatus(`Loading default snapshot: ${DEFAULT_SNAPSHOT_URL}`);
-  autoLoadWithRetry(DEFAULT_SNAPSHOT_URL, DEFAULT_SNAPSHOT_URL);
+  setStatus(`Loading default snapshot…`);
+  autoLoadWithRetry(DEFAULT_SNAPSHOT_URL, DEFAULT_SNAPSHOT_URL).catch((e) => {
+    console.error("Auto-load failed:", e);
+    setStatus(`Load failed: ${e?.message ?? e}`, "bad");
+  });
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -59,7 +59,7 @@
         >
           <div id="progressBar" class="progressBar"></div>
         </div>
-        <span id="status" class="statusInline"></span>
+        <span id="status" class="statusInline">Initialising…</span>
       </div>
     </header>
 
@@ -275,6 +275,33 @@
       </nav>
     </main>
 
+    <!-- Issue #126: catch unhandled errors so the user always gets feedback. -->
+    <script>
+      window.addEventListener("error", function (e) {
+        var s = document.getElementById("status");
+        if (s && !s.dataset.appLoaded) {
+          s.textContent = "Error: " + (e.message || e) +
+            ". Try a hard refresh.";
+          s.className = "statusInline bad";
+        }
+      });
+      window.addEventListener("unhandledrejection", function (e) {
+        var s = document.getElementById("status");
+        if (s && !s.dataset.appLoaded) {
+          var msg = e.reason
+            ? e.reason.message || String(e.reason)
+            : "Unknown error";
+          s.textContent = "Error: " + msg + ". Try a hard refresh.";
+          s.className = "statusInline bad";
+        }
+      });
+    </script>
+    <noscript>
+      <p style="padding: 1rem; color: #ef4444">
+        JavaScript is required to run NEAT-AI Explore.
+      </p>
+    </noscript>
+
     <script type="module">
       // Register the Service Worker *before* importing the app module.
       //
@@ -288,6 +315,11 @@
       // and can remain pending forever if installation/activation fails (e.g.
       // quota exceeded, privacy mode restrictions, or an unhandled SW install
       // error). Use a timeout so the app still boots in degraded mode.
+      //
+      // Issue #126 (26-Feb-2026): if the dynamic import fails (e.g. stale
+      // Service Worker cache, network error, or JS error during module
+      // evaluation), show a visible error to the user instead of failing
+      // silently.
       (async () => {
         if ("serviceWorker" in navigator) {
           try {
@@ -315,7 +347,29 @@
         const v = buildId.includes("__BUILD_ID__")
           ? String(Date.now())
           : buildId;
-        await import(`./app.js?v=${v}`);
+        try {
+          await import(`./app.js?v=${v}`);
+        } catch (err) {
+          console.error("App failed to load:", err);
+          const statusEl = document.getElementById("status");
+          if (statusEl) {
+            statusEl.textContent = `Failed to load app: ${
+              err?.message ?? err
+            }. Try a hard refresh (Ctrl+Shift+R).`;
+            statusEl.className = "statusInline bad";
+          }
+          // Attempt to clear stale Service Worker caches so the next
+          // reload has a better chance of succeeding.
+          if (typeof caches !== "undefined") {
+            try {
+              const keys = await caches.keys();
+              await Promise.all(keys.map((k) => caches.delete(k)));
+              console.warn("Cleared all caches after load failure.");
+            } catch (_e) {
+              // Non-fatal.
+            }
+          }
+        }
       })();
     </script>
 

--- a/docs/pr-summary-126.md
+++ b/docs/pr-summary-126.md
@@ -1,0 +1,55 @@
+## Summary
+
+Fixed silent loading failures where the app showed no UI indication of errors
+when loading failed. The root causes were:
+
+1. **Unhandled dynamic `import()` rejection**: The bootstrap script in
+   `index.html` had no error handling on the `await import('./app.js')` call.
+   If the module failed to load (stale SW cache, network error, JS error during
+   module evaluation), users saw a blank page with no feedback.
+
+2. **Missing `.catch()` on fire-and-forget promises**: `autoLoadWithRetry()`
+   and the manual fetch button handler called async functions without catching
+   rejections, causing unhandled promise rejections.
+
+3. **Incomplete Service Worker pre-cache**: Five shared modules imported by
+   `app.js` were missing from the SW's `STATIC_FILES` list, making offline
+   loading fragile after deploys.
+
+Fixes applied:
+
+- **`index.html`**: Added `try/catch` around the dynamic import with a visible
+  error message. Added global `error` and `unhandledrejection` listeners before
+  the module script to catch early failures. Added `"Initialising…"` default
+  text in the status span for immediate pre-JS feedback. Added `<noscript>`
+  fallback. On import failure, automatically clears stale SW caches for
+  self-healing on next reload.
+
+- **`app.js`**: Added `.catch()` handlers on `autoLoadWithRetry()` calls and
+  the manual fetch button handler. Added `data-appLoaded` flag so global error
+  handlers yield to app-level status once the module has loaded.
+
+- **`sw.js`**: Added five missing shared modules to `STATIC_FILES`
+  (`config.js`, `graph_analysis.js`, `creature_overview.js`, `transitions.js`,
+  `sparkline.js`) so the app works offline after a single online visit.
+
+Closes #126.
+
+## Evidence
+
+This is a loading/error-handling fix — the visual change is the addition of a
+pre-JS "Initialising…" status message and proper error messages on failure. The
+fix was verified by:
+
+- Confirmed all 233 tests pass (including 4 new loading robustness tests)
+- Quality gate (`./quality.sh`) passes cleanly
+- End-to-end loading test with the live snapshot (67 MB uncompressed) completes
+  successfully with correct computation results
+
+## Test Plan
+
+- Added `tests/loading_robustness_test.ts` with 4 tests:
+  - SW `STATIC_FILES` includes all modules imported by `app.js`
+  - `index.html` has error handling on dynamic import
+  - `index.html` shows a pre-JS loading indicator
+  - `index.html` has a global error handler for unhandled errors

--- a/docs/pr-summary-126.md
+++ b/docs/pr-summary-126.md
@@ -4,12 +4,12 @@ Fixed silent loading failures where the app showed no UI indication of errors
 when loading failed. The root causes were:
 
 1. **Unhandled dynamic `import()` rejection**: The bootstrap script in
-   `index.html` had no error handling on the `await import('./app.js')` call.
-   If the module failed to load (stale SW cache, network error, JS error during
+   `index.html` had no error handling on the `await import('./app.js')` call. If
+   the module failed to load (stale SW cache, network error, JS error during
    module evaluation), users saw a blank page with no feedback.
 
-2. **Missing `.catch()` on fire-and-forget promises**: `autoLoadWithRetry()`
-   and the manual fetch button handler called async functions without catching
+2. **Missing `.catch()` on fire-and-forget promises**: `autoLoadWithRetry()` and
+   the manual fetch button handler called async functions without catching
    rejections, causing unhandled promise rejections.
 
 3. **Incomplete Service Worker pre-cache**: Five shared modules imported by
@@ -25,13 +25,13 @@ Fixes applied:
   fallback. On import failure, automatically clears stale SW caches for
   self-healing on next reload.
 
-- **`app.js`**: Added `.catch()` handlers on `autoLoadWithRetry()` calls and
-  the manual fetch button handler. Added `data-appLoaded` flag so global error
+- **`app.js`**: Added `.catch()` handlers on `autoLoadWithRetry()` calls and the
+  manual fetch button handler. Added `data-appLoaded` flag so global error
   handlers yield to app-level status once the module has loaded.
 
-- **`sw.js`**: Added five missing shared modules to `STATIC_FILES`
-  (`config.js`, `graph_analysis.js`, `creature_overview.js`, `transitions.js`,
-  `sparkline.js`) so the app works offline after a single online visit.
+- **`sw.js`**: Added five missing shared modules to `STATIC_FILES` (`config.js`,
+  `graph_analysis.js`, `creature_overview.js`, `transitions.js`, `sparkline.js`)
+  so the app works offline after a single online visit.
 
 Closes #126.
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -32,8 +32,14 @@ const STATIC_FILES = [
   "./graph/index.html",
   `./graph/graph.js?v=${VERSION}`,
   `./graph/graph.css?v=${VERSION}`,
-  // Shared modules for multiple views.
+  // Shared modules for multiple views (Issue #126: pre-cache all modules
+  // that app.js imports so the app works offline after a single online visit).
   "./shared/snapshot_loader.js",
+  "./shared/config.js",
+  "./shared/graph_analysis.js",
+  "./shared/creature_overview.js",
+  "./shared/transitions.js",
+  "./shared/sparkline.js",
   "./shared/theme.js",
   "./shared/colour_maps.js",
   "./icons/icon-72x72.png",

--- a/tests/loading_robustness_test.ts
+++ b/tests/loading_robustness_test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for loading robustness (Issue #126).
+ *
+ * Verifies that:
+ * 1. The Service Worker pre-caches all modules that app.js imports.
+ * 2. The bootstrap script in index.html has error handling on the dynamic
+ *    import so users see a visible error when loading fails.
+ * 3. A pre-JS loading indicator exists so the user sees something immediately.
+ */
+
+import { assert } from "./test_helpers.ts";
+
+function repoPath(...parts: string[]): string {
+  const url = new URL(import.meta.url);
+  const here = url.pathname;
+  const root = here.replace(/\/tests\/loading_robustness_test\.ts$/, "");
+  return [root, ...parts].join("/");
+}
+
+/**
+ * Extract ES module import paths from a JS file's import statements.
+ * Returns relative paths like "./shared/config.js".
+ */
+function extractImportPaths(source: string): string[] {
+  const paths: string[] = [];
+  // Match: import { ... } from "path";  and  import "path";
+  const re = /\bfrom\s+["']([^"']+)["']|import\s+["']([^"']+)["']/g;
+  let m;
+  while ((m = re.exec(source)) !== null) {
+    const p = m[1] ?? m[2];
+    if (p && p.startsWith("./")) paths.push(p);
+  }
+  return paths;
+}
+
+Deno.test("SW STATIC_FILES includes all modules imported by app.js", async () => {
+  const appSource = await Deno.readTextFile(repoPath("docs", "app.js"));
+  const swSource = await Deno.readTextFile(repoPath("docs", "sw.js"));
+
+  const appImports = extractImportPaths(appSource);
+  assert(appImports.length > 0, "app.js should have imports");
+
+  // SW uses template literals like `./app.js?v=${VERSION}` — strip any
+  // query-string / template suffix for comparison.
+  const swEntries = swSource.match(/["'`]\.\/.+?["'`]/g) ?? [];
+  const swPaths = new Set(
+    swEntries.map((e) =>
+      e.slice(1, -1).replace(/\?v=.*$/, "").replace(/\$\{.*?\}/, "")
+    ),
+  );
+
+  const missing: string[] = [];
+  for (const imp of appImports) {
+    if (!swPaths.has(imp)) missing.push(imp);
+  }
+
+  assert(
+    missing.length === 0,
+    `SW STATIC_FILES is missing modules imported by app.js: ${
+      missing.join(", ")
+    }`,
+  );
+});
+
+Deno.test("index.html has error handling on dynamic import", async () => {
+  const html = await Deno.readTextFile(repoPath("docs", "index.html"));
+
+  // The dynamic import of app.js should be wrapped in try/catch.
+  assert(
+    html.includes("catch") && html.includes("import("),
+    "index.html should have a catch handler around the dynamic import",
+  );
+});
+
+Deno.test("index.html shows a pre-JS loading indicator", async () => {
+  const html = await Deno.readTextFile(repoPath("docs", "index.html"));
+
+  // The status span should have default text content so users see something
+  // before JavaScript has loaded.
+  assert(
+    /id="status"[^>]*>[^<]+</.test(html),
+    "status element should have default text content for pre-JS feedback",
+  );
+});
+
+Deno.test("index.html has a global error handler for unhandled errors", async () => {
+  const html = await Deno.readTextFile(repoPath("docs", "index.html"));
+
+  assert(
+    html.includes("unhandledrejection"),
+    "index.html should listen for unhandledrejection events",
+  );
+});


### PR DESCRIPTION
## Summary

Fixed silent loading failures where the app showed no UI indication of errors
when loading failed. The root causes were:

1. **Unhandled dynamic `import()` rejection**: The bootstrap script in
   `index.html` had no error handling on the `await import('./app.js')` call.
   If the module failed to load (stale SW cache, network error, JS error during
   module evaluation), users saw a blank page with no feedback.

2. **Missing `.catch()` on fire-and-forget promises**: `autoLoadWithRetry()`
   and the manual fetch button handler called async functions without catching
   rejections, causing unhandled promise rejections.

3. **Incomplete Service Worker pre-cache**: Five shared modules imported by
   `app.js` were missing from the SW's `STATIC_FILES` list, making offline
   loading fragile after deploys.

Fixes applied:

- **`index.html`**: Added `try/catch` around the dynamic import with a visible
  error message. Added global `error` and `unhandledrejection` listeners before
  the module script to catch early failures. Added `"Initialising…"` default
  text in the status span for immediate pre-JS feedback. Added `<noscript>`
  fallback. On import failure, automatically clears stale SW caches for
  self-healing on next reload.

- **`app.js`**: Added `.catch()` handlers on `autoLoadWithRetry()` calls and
  the manual fetch button handler. Added `data-appLoaded` flag so global error
  handlers yield to app-level status once the module has loaded.

- **`sw.js`**: Added five missing shared modules to `STATIC_FILES`
  (`config.js`, `graph_analysis.js`, `creature_overview.js`, `transitions.js`,
  `sparkline.js`) so the app works offline after a single online visit.

Closes #126.

## Evidence

This is a loading/error-handling fix — the visual change is the addition of a
pre-JS "Initialising…" status message and proper error messages on failure. The
fix was verified by:

- Confirmed all 233 tests pass (including 4 new loading robustness tests)
- Quality gate (`./quality.sh`) passes cleanly
- End-to-end loading test with the live snapshot (67 MB uncompressed) completes
  successfully with correct computation results

## Test Plan

- Added `tests/loading_robustness_test.ts` with 4 tests:
  - SW `STATIC_FILES` includes all modules imported by `app.js`
  - `index.html` has error handling on dynamic import
  - `index.html` shows a pre-JS loading indicator
  - `index.html` has a global error handler for unhandled errors


🤖 Generated with [Claude Code](https://claude.com/claude-code)