### PR TITLE
Add starfield view to service worker cache and fix PWA manifest icons (#129)

### DIFF
--- a/docs/manifest.webmanifest
+++ b/docs/manifest.webmanifest
@@ -15,49 +15,49 @@
       "src": "icons/icon-72x72.png",
       "sizes": "72x72",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "icons/icon-96x96.png",
       "sizes": "96x96",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "icons/icon-128x128.png",
       "sizes": "128x128",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "icons/icon-144x144.png",
       "sizes": "144x144",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "icons/icon-152x152.png",
       "sizes": "152x152",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "icons/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "icons/icon-384x384.png",
       "sizes": "384x384",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "icons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     }
   ],
   "screenshots": [

--- a/docs/pr-summary-129.md
+++ b/docs/pr-summary-129.md
@@ -1,0 +1,39 @@
+## Summary
+
+Add starfield view to the service worker's static file cache and fix PWA manifest
+icon purpose values. Closes #129.
+
+### Service worker — starfield caching
+- Added `./starfield/index.html`, `./starfield/starfield.js`, and
+  `./starfield/starfield.css` to `STATIC_FILES` in `docs/sw.js`
+- Added a navigation handler for `/starfield/` URLs (matching the existing
+  `isGraphNav` pattern) so offline navigation serves the cached starfield shell
+
+### Manifest icons
+- Changed icon purpose from `"any maskable"` to `"any"` — the combined value is
+  not best practice and no dedicated maskable icons exist yet
+
+### Test updates
+- `tests/pwa_test.ts`: added starfield files to the PWA file existence check,
+  added tests for SW static file inclusion and starfield navigation handling,
+  added test verifying manifest icons use single-purpose values
+- `tests/lint_coverage_test.ts`: added `docs/starfield/starfield.js` to expected
+  lint exclusions (DOM-dependent)
+
+## Evidence
+
+No UI changes — this is a caching/manifest configuration fix. Verified via tests
+that confirm the starfield files are referenced in the service worker and manifest
+icons have correct purpose values.
+
+## Test Plan
+
+- `tests/pwa_test.ts` — "docs PWA files exist" now includes starfield files
+- `tests/pwa_test.ts` — "service worker caches starfield files" verifies SW
+  includes all three starfield paths
+- `tests/pwa_test.ts` — "service worker handles starfield navigation" verifies
+  the SW recognises starfield URLs
+- `tests/pwa_test.ts` — "manifest icons use single-purpose values" verifies each
+  icon has exactly one purpose value
+- `tests/lint_coverage_test.ts` — verifies `starfield.js` is in lint exclusions
+- All 305 tests pass, `./quality.sh` passes cleanly

--- a/docs/pr-summary-129.md
+++ b/docs/pr-summary-129.md
@@ -1,19 +1,22 @@
 ## Summary
 
-Add starfield view to the service worker's static file cache and fix PWA manifest
-icon purpose values. Closes #129.
+Add starfield view to the service worker's static file cache and fix PWA
+manifest icon purpose values. Closes #129.
 
 ### Service worker — starfield caching
+
 - Added `./starfield/index.html`, `./starfield/starfield.js`, and
   `./starfield/starfield.css` to `STATIC_FILES` in `docs/sw.js`
 - Added a navigation handler for `/starfield/` URLs (matching the existing
   `isGraphNav` pattern) so offline navigation serves the cached starfield shell
 
 ### Manifest icons
+
 - Changed icon purpose from `"any maskable"` to `"any"` — the combined value is
   not best practice and no dedicated maskable icons exist yet
 
 ### Test updates
+
 - `tests/pwa_test.ts`: added starfield files to the PWA file existence check,
   added tests for SW static file inclusion and starfield navigation handling,
   added test verifying manifest icons use single-purpose values
@@ -23,8 +26,8 @@ icon purpose values. Closes #129.
 ## Evidence
 
 No UI changes — this is a caching/manifest configuration fix. Verified via tests
-that confirm the starfield files are referenced in the service worker and manifest
-icons have correct purpose values.
+that confirm the starfield files are referenced in the service worker and
+manifest icons have correct purpose values.
 
 ## Test Plan
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -32,6 +32,11 @@ const STATIC_FILES = [
   "./graph/index.html",
   `./graph/graph.js?v=${VERSION}`,
   `./graph/graph.css?v=${VERSION}`,
+  // Starfield view (Issue #129): separate entry point that re-exports the graph
+  // renderer — must be cached for offline access.
+  "./starfield/index.html",
+  `./starfield/starfield.js?v=${VERSION}`,
+  `./starfield/starfield.css?v=${VERSION}`,
   // Shared modules for multiple views (Issue #126: all shared modules must be
   // listed so they are precached and invalidated with each deploy — missing
   // modules can be served stale by cacheFirst, breaking imports).
@@ -201,9 +206,13 @@ self.addEventListener("fetch", (event) => {
       }
     })();
     const isGraphNav = /\/graph(\/|$)/.test(path);
-    event.respondWith(
-      cacheFirst(isGraphNav ? "./graph/index.html" : "./index.html"),
-    );
+    const isStarfieldNav = /\/starfield(\/|$)/.test(path);
+    const shell = isGraphNav
+      ? "./graph/index.html"
+      : isStarfieldNav
+      ? "./starfield/index.html"
+      : "./index.html";
+    event.respondWith(cacheFirst(shell));
     return;
   }
 

--- a/tests/lint_coverage_test.ts
+++ b/tests/lint_coverage_test.ts
@@ -97,6 +97,7 @@ Deno.test("deno lint configuration excludes DOM-dependent files", async () => {
     "docs/app.js",
     "docs/sw.js",
     "docs/shared/theme.js",
+    "docs/starfield/starfield.js",
   ];
   for (const exc of expectedExclusions) {
     assertEquals(

--- a/tests/pwa_test.ts
+++ b/tests/pwa_test.ts
@@ -1,4 +1,4 @@
-import { assert } from "./test_helpers.ts";
+import { assert, assertEquals } from "./test_helpers.ts";
 
 function repoPath(...parts: string[]): string {
   const url = new URL(import.meta.url);
@@ -32,12 +32,73 @@ Deno.test("docs PWA files exist", async () => {
     repoPath("docs", "graph", "index.html"),
     repoPath("docs", "graph", "graph.js"),
     repoPath("docs", "graph", "graph.css"),
+    repoPath("docs", "starfield", "index.html"),
+    repoPath("docs", "starfield", "starfield.js"),
+    repoPath("docs", "starfield", "starfield.css"),
     repoPath("docs", "shared", "snapshot_loader.js"),
     repoPath("docs", "shared", "theme.js"),
     repoPath("docs", "shared", "colour_maps.js"),
   ];
   for (const p of paths) {
     await Deno.stat(p);
+  }
+});
+
+Deno.test("service worker caches starfield files", async () => {
+  const swPath = repoPath("docs", "sw.js");
+  const swSource = await Deno.readTextFile(swPath);
+
+  const requiredPaths = [
+    "./starfield/index.html",
+    "./starfield/starfield.js",
+    "./starfield/starfield.css",
+  ];
+
+  for (const path of requiredPaths) {
+    assert(
+      swSource.includes(path),
+      `sw.js STATIC_FILES should include "${path}"`,
+    );
+  }
+});
+
+Deno.test("service worker handles starfield navigation", async () => {
+  const swPath = repoPath("docs", "sw.js");
+  const swSource = await Deno.readTextFile(swPath);
+
+  // The SW should have a navigation handler that recognises starfield URLs
+  assert(
+    swSource.includes("starfield"),
+    "sw.js should handle starfield navigation",
+  );
+  assert(
+    swSource.includes("./starfield/index.html"),
+    "sw.js should serve starfield/index.html for starfield navigation",
+  );
+});
+
+Deno.test("manifest icons use single-purpose values", async () => {
+  const manifestPath = repoPath("docs", "manifest.webmanifest");
+  const manifest = JSON.parse(await Deno.readTextFile(manifestPath));
+
+  for (const icon of manifest.icons) {
+    assert(
+      typeof icon.purpose === "string",
+      `Icon ${icon.src} should have a purpose field`,
+    );
+    // Each icon entry should have exactly one purpose, not "any maskable"
+    const purposes = icon.purpose.split(/\s+/);
+    assertEquals(
+      purposes.length,
+      1,
+      `Icon ${icon.src} should have a single purpose value, got "${icon.purpose}"`,
+    );
+    assert(
+      purposes[0] === "any" || purposes[0] === "maskable",
+      `Icon ${icon.src} purpose should be "any" or "maskable", got "${
+        purposes[0]
+      }"`,
+    );
   }
 });
 


### PR DESCRIPTION
## Summary

Add starfield view to the service worker's static file cache and fix PWA manifest
icon purpose values. Closes #129.

### Service worker — starfield caching
- Added `./starfield/index.html`, `./starfield/starfield.js`, and
  `./starfield/starfield.css` to `STATIC_FILES` in `docs/sw.js`
- Added a navigation handler for `/starfield/` URLs (matching the existing
  `isGraphNav` pattern) so offline navigation serves the cached starfield shell

### Manifest icons
- Changed icon purpose from `"any maskable"` to `"any"` — the combined value is
  not best practice and no dedicated maskable icons exist yet

### Test updates
- `tests/pwa_test.ts`: added starfield files to the PWA file existence check,
  added tests for SW static file inclusion and starfield navigation handling,
  added test verifying manifest icons use single-purpose values
- `tests/lint_coverage_test.ts`: added `docs/starfield/starfield.js` to expected
  lint exclusions (DOM-dependent)

## Evidence

No UI changes — this is a caching/manifest configuration fix. Verified via tests
that confirm the starfield files are referenced in the service worker and manifest
icons have correct purpose values.

## Test Plan

- `tests/pwa_test.ts` — "docs PWA files exist" now includes starfield files
- `tests/pwa_test.ts` — "service worker caches starfield files" verifies SW
  includes all three starfield paths
- `tests/pwa_test.ts` — "service worker handles starfield navigation" verifies
  the SW recognises starfield URLs
- `tests/pwa_test.ts` — "manifest icons use single-purpose values" verifies each
  icon has exactly one purpose value
- `tests/lint_coverage_test.ts` — verifies `starfield.js` is in lint exclusions
- All 305 tests pass, `./quality.sh` passes cleanly