### PR TITLE
Add debouncing, lazy correlation, and graph label dirty flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Only pure, DOM-free modules can be tested in Deno:
 | `docs/shared/diagnostics_scan.js`  | `scan1d`, `scan2d`, `computeNonFiniteIssues`, `computeErrorConcentrationIssues`                                                           |
 | `docs/shared/theme.js`             | `normaliseThemeMode`, `cycleThemeMode`, `themeModeLabel`, `themeModeGlyph`                                                                |
 | `docs/shared/ui_helpers.js`        | `escapeHtml`, `extractTooltips`                                                                                                           |
+| `docs/shared/debounce.js`         | `debounce`                                                                                                                                |
 
 Browser-only code (DOM, WebGL, Service Worker) cannot be unit-tested in Deno —
 skip it rather than faking it with grep-based assertions.

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Only pure, DOM-free modules can be tested in Deno:
 | `docs/shared/diagnostics_scan.js`  | `scan1d`, `scan2d`, `computeNonFiniteIssues`, `computeErrorConcentrationIssues`                                                           |
 | `docs/shared/theme.js`             | `normaliseThemeMode`, `cycleThemeMode`, `themeModeLabel`, `themeModeGlyph`                                                                |
 | `docs/shared/ui_helpers.js`        | `escapeHtml`, `extractTooltips`                                                                                                           |
-| `docs/shared/debounce.js`         | `debounce`                                                                                                                                |
+| `docs/shared/debounce.js`          | `debounce`                                                                                                                                |
 
 Browser-only code (DOM, WebGL, Service Worker) cannot be unit-tested in Deno —
 skip it rather than faking it with grep-based assertions.

--- a/docs/app.js
+++ b/docs/app.js
@@ -72,6 +72,7 @@ import {
 } from "./shared/diagnostics_scan.js";
 import { initThemeMode } from "./shared/theme.js";
 import { escapeHtml, extractTooltips } from "./shared/ui_helpers.js";
+import { debounce } from "./shared/debounce.js";
 
 let SNAPSHOT = null;
 let synapses = [];
@@ -98,6 +99,7 @@ let DIAG_INPUTS = {
 };
 
 let DISCOVERY_CANDIDATES = [];
+let correlationsComputed = false;
 let selectedCandidateKey = null;
 let currentNeuronTab = "details"; // details | issues | candidates
 
@@ -690,6 +692,7 @@ async function loadSnapshot(source, label) {
         inputCount: creature.input ?? 0,
         candidates: DISCOVERY_CANDIDATES,
       });
+      correlationsComputed = false;
 
       // Observations dashboard (reachability + low-signal flags).
       INPUT_DASH = computeInputDashboard({
@@ -716,6 +719,7 @@ async function loadSnapshot(source, label) {
       };
       DISCOVERY_CANDIDATES = [];
       INPUT_DASH = { inputCount: creature.input ?? 0, rows: [] };
+      correlationsComputed = false;
     }
 
     selectedCandidateKey = null;
@@ -801,6 +805,21 @@ let obsFilter = {
 
 function openObsModal() {
   if (!el.obsModal || !el.obsModalBody || !el.obsModalTitle) return;
+
+  // Lazily compute correlations on first modal open (deferred from snapshot
+  // load to avoid O(n^2) work when the user never opens the modal).
+  if (!correlationsComputed && SNAPSHOT) {
+    const creature = SNAPSHOT.creature ?? {};
+    DIAG_INPUTS.correlatedPairs = computeTopInputCorrelations({
+      recording: SNAPSHOT.recording ?? null,
+      inputCount: creature.input ?? 0,
+      maxInputs: 80,
+      sampleSize: 512,
+      topK: 12,
+    });
+    correlationsComputed = true;
+  }
+
   el.obsModal.classList.add("isOpen");
   el.obsModal.setAttribute("aria-hidden", "false");
   renderObsModal();
@@ -2693,14 +2712,9 @@ function computeInputIssues({ recording, inputCount, candidates }) {
     }
   }
 
-  // Highly correlated input pairs (guard-railed).
-  const correlatedPairs = computeTopInputCorrelations({
-    recording,
-    inputCount,
-    maxInputs: 80,
-    sampleSize: 512,
-    topK: 12,
-  });
+  // Correlation computation is deferred to the first Observations modal open
+  // (see openObsModal) to avoid expensive O(n^2) work at snapshot load time.
+  const correlatedPairs = [];
 
   // Candidate coverage for input-N nodes.
   const coverage = [];
@@ -3564,11 +3578,14 @@ function initInboundFilters() {
   syncInboundFilterControls();
 
   if (el.synapseMinAlloc) {
+    const debouncedRenderSynapses = debounce(() => {
+      if (trace.length > 0) renderSynapseList(trace[trace.length - 1]);
+    }, 150);
     el.synapseMinAlloc.addEventListener("input", () => {
       const n = parseMaybeNumber(el.synapseMinAlloc.value);
       inboundMinAllocImpact = n != null && n > 0 ? n : 0;
       resetInboundRenderLimit();
-      if (trace.length > 0) renderSynapseList(trace[trace.length - 1]);
+      debouncedRenderSynapses();
     });
   }
   if (el.synapseTopK) {

--- a/docs/graph/graph.js
+++ b/docs/graph/graph.js
@@ -4036,16 +4036,42 @@ function initStarfield() {
     console.error("Auto-load failed:", e);
   });
 
-  // Animation loop
+  // Animation loop — track previous camera pose so we can skip label updates
+  // when nothing has changed (Issue #130).
   let lastT = performance.now();
+  let prevYaw = NaN;
+  let prevPitch = NaN;
+  let prevPosX = NaN;
+  let prevPosY = NaN;
+  let prevPosZ = NaN;
+  let prevFocusUuid = null;
   function frame(now) {
     const dt = Math.min(0.05, Math.max(0, (now - lastT) / 1000));
     lastT = now;
     renderer.update(dt);
     renderer.render();
-    // Keep labels in sync with camera motion.
+    // Keep labels in sync with camera motion — but skip the update when the
+    // camera pose and focus UUID are unchanged to avoid unnecessary DOM work.
     const focusUuid = renderer?.meta?.[renderer.focusIndex]?.uuid ?? null;
-    if (focusUuid) updateLabelsForFocus(focusUuid);
+    if (focusUuid) {
+      const yaw = renderer.yaw;
+      const pitch = renderer.pitch;
+      const px = renderer.pos?.x ?? 0;
+      const py = renderer.pos?.y ?? 0;
+      const pz = renderer.pos?.z ?? 0;
+      const changed = focusUuid !== prevFocusUuid ||
+        yaw !== prevYaw || pitch !== prevPitch ||
+        px !== prevPosX || py !== prevPosY || pz !== prevPosZ;
+      if (changed) {
+        updateLabelsForFocus(focusUuid);
+        prevYaw = yaw;
+        prevPitch = pitch;
+        prevPosX = px;
+        prevPosY = py;
+        prevPosZ = pz;
+        prevFocusUuid = focusUuid;
+      }
+    }
     requestAnimationFrame(frame);
   }
   requestAnimationFrame(frame);

--- a/docs/pr-summary-130.md
+++ b/docs/pr-summary-130.md
@@ -1,0 +1,35 @@
+## Summary
+
+Three performance improvements for large snapshots. Closes #130.
+
+1. **Debounced synapse filter**: The `synapseMinAlloc` input now uses a 150ms
+   debounce, so `renderSynapseList` only fires after the user pauses typing —
+   avoiding expensive DOM rebuilds on every keystroke for creatures with hundreds
+   of synapses.
+
+2. **Lazy correlation computation**: `computeTopInputCorrelations` is no longer
+   called eagerly during `loadSnapshot`. Instead, it runs on the first
+   Observations modal open and is cached for subsequent opens. This reduces
+   initial snapshot load time, especially for creatures with many inputs (up to
+   80×80 = 3,160 pairs).
+
+3. **Graph view: skip label updates when nothing changed**: The animation loop
+   now tracks the previous camera pose (yaw, pitch, position) and focus UUID.
+   `updateLabelsForFocus` is only called when something actually changed,
+   avoiding unnecessary DOM work every frame.
+
+## Evidence
+
+These are non-visual performance improvements. No UI changes to screenshot.
+Verified by running `./quality.sh` — all 342 tests pass.
+
+## Test Plan
+
+- Added `tests/debounce_test.ts` with 5 tests covering:
+  - Delayed invocation after quiet period
+  - Timer reset on rapid calls
+  - Argument forwarding
+  - `cancel()` method
+  - Return type validation
+- Existing correlation and graph tests continue to pass unchanged
+- `./quality.sh` passes cleanly (format, lint, 342 tests)

--- a/docs/pr-summary-130.md
+++ b/docs/pr-summary-130.md
@@ -4,8 +4,8 @@ Three performance improvements for large snapshots. Closes #130.
 
 1. **Debounced synapse filter**: The `synapseMinAlloc` input now uses a 150ms
    debounce, so `renderSynapseList` only fires after the user pauses typing —
-   avoiding expensive DOM rebuilds on every keystroke for creatures with hundreds
-   of synapses.
+   avoiding expensive DOM rebuilds on every keystroke for creatures with
+   hundreds of synapses.
 
 2. **Lazy correlation computation**: `computeTopInputCorrelations` is no longer
    called eagerly during `loadSnapshot`. Instead, it runs on the first

--- a/docs/shared/debounce.js
+++ b/docs/shared/debounce.js
@@ -1,0 +1,21 @@
+/**
+ * Creates a debounced version of a function that delays invocation until
+ * after `delayMs` milliseconds have elapsed since the last call.
+ *
+ * @param {Function} fn - The function to debounce.
+ * @param {number} delayMs - Delay in milliseconds.
+ * @returns {Function & { cancel: () => void }} Debounced function with a
+ *   `cancel()` method to clear any pending invocation.
+ */
+export function debounce(fn, delayMs) {
+  let timerId = 0;
+
+  /** @type {Function & { cancel: () => void }} */
+  const debounced = function (...args) {
+    clearTimeout(timerId);
+    timerId = setTimeout(() => fn.apply(this, args), delayMs);
+  };
+
+  debounced.cancel = () => clearTimeout(timerId);
+  return debounced;
+}

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -52,6 +52,7 @@ const STATIC_FILES = [
   "./shared/discovery.js",
   "./shared/diagnostics_scan.js",
   "./shared/ui_helpers.js",
+  "./shared/debounce.js",
   "./icons/icon-72x72.png",
   "./icons/icon-16x16.png",
   "./icons/icon-32x32.png",

--- a/tests/debounce_test.ts
+++ b/tests/debounce_test.ts
@@ -1,0 +1,63 @@
+import { debounce } from "../docs/shared/debounce.js";
+import { assert, assertEquals } from "./test_helpers.ts";
+
+/** Helper: wait for a given number of milliseconds. */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+Deno.test("debounce delays invocation until after the quiet period", async () => {
+  let callCount = 0;
+  const fn = debounce(() => {
+    callCount++;
+  }, 50);
+  fn();
+  assertEquals(callCount, 0, "should not fire immediately");
+  await delay(80);
+  assertEquals(callCount, 1, "should fire after the delay");
+});
+
+Deno.test("debounce resets the timer on rapid calls", async () => {
+  let callCount = 0;
+  const fn = debounce(() => {
+    callCount++;
+  }, 50);
+  fn();
+  await delay(20);
+  fn(); // reset timer
+  await delay(20);
+  fn(); // reset timer again
+  assertEquals(callCount, 0, "should not fire during rapid calls");
+  await delay(80);
+  assertEquals(callCount, 1, "should fire exactly once after final call");
+});
+
+Deno.test("debounce passes arguments to the wrapped function", async () => {
+  let received: number[] = [];
+  const fn = debounce((...args: number[]) => {
+    received = args;
+  }, 30);
+  fn(1, 2, 3);
+  await delay(60);
+  assertEquals(received.length, 3);
+  assertEquals(received[0], 1);
+  assertEquals(received[1], 2);
+  assertEquals(received[2], 3);
+});
+
+Deno.test("debounce cancel() prevents pending invocation", async () => {
+  let callCount = 0;
+  const fn = debounce(() => {
+    callCount++;
+  }, 50);
+  fn();
+  fn.cancel();
+  await delay(80);
+  assertEquals(callCount, 0, "should not fire after cancel");
+});
+
+Deno.test("debounce returns a function with cancel method", () => {
+  const fn = debounce(() => {}, 100);
+  assert(typeof fn === "function", "debounced should be callable");
+  assert(typeof fn.cancel === "function", "should have cancel method");
+});


### PR DESCRIPTION
## Summary

Three performance improvements for large snapshots. Closes #130.

1. **Debounced synapse filter**: The `synapseMinAlloc` input now uses a 150ms
   debounce, so `renderSynapseList` only fires after the user pauses typing —
   avoiding expensive DOM rebuilds on every keystroke for creatures with hundreds
   of synapses.

2. **Lazy correlation computation**: `computeTopInputCorrelations` is no longer
   called eagerly during `loadSnapshot`. Instead, it runs on the first
   Observations modal open and is cached for subsequent opens. This reduces
   initial snapshot load time, especially for creatures with many inputs (up to
   80×80 = 3,160 pairs).

3. **Graph view: skip label updates when nothing changed**: The animation loop
   now tracks the previous camera pose (yaw, pitch, position) and focus UUID.
   `updateLabelsForFocus` is only called when something actually changed,
   avoiding unnecessary DOM work every frame.

## Evidence

These are non-visual performance improvements. No UI changes to screenshot.
Verified by running `./quality.sh` — all 342 tests pass.

## Test Plan

- Added `tests/debounce_test.ts` with 5 tests covering:
  - Delayed invocation after quiet period
  - Timer reset on rapid calls
  - Argument forwarding
  - `cancel()` method
  - Return type validation
- Existing correlation and graph tests continue to pass unchanged
- `./quality.sh` passes cleanly (format, lint, 342 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)