### PR TITLE
Add Semgrep SAST Scanning workflow (Issue #153)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,19 @@
+name: Semgrep
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@v4
+      - run: semgrep ci --config p/default
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/docs/pr-summary-153.md
+++ b/docs/pr-summary-153.md
@@ -1,0 +1,41 @@
+## Summary
+
+Added a Semgrep SAST scanning GitHub Actions workflow that runs on every pull
+request, executing `semgrep ci --config p/default` inside the official
+`semgrep/semgrep` container. This strengthens the repository's security posture
+by catching common code-level vulnerabilities at PR review time. Closes #153.
+
+## Evidence
+
+This is a CI/workflow change with no UI surface. Verification was done via a new
+Deno test suite (`tests/semgrep_workflow_test.ts`) that parses the workflow YAML
+and asserts on its structure, and via the full quality gate.
+
+```mermaid
+flowchart LR
+    A[Pull Request opened] --> B[GitHub Actions]
+    B --> C[Semgrep container]
+    C --> D[semgrep ci --config p/default]
+    D --> E{Findings?}
+    E -- yes --> F[Annotate PR / fail check]
+    E -- no --> G[Pass]
+```
+
+Quality gate output:
+
+```
+ok | 364 passed | 0 failed (7s)
+==> OK
+```
+
+## Test Plan
+
+- Added `tests/semgrep_workflow_test.ts` with six checks covering:
+  - File presence at `.github/workflows/semgrep.yml`
+  - Valid YAML and `name: Semgrep`
+  - `pull_request` trigger declared
+  - Minimal `contents: read` permission
+  - Job runs inside the `semgrep/semgrep` container on `ubuntu-latest`
+  - Steps include `actions/checkout@` and a `semgrep ci --config ...` run that
+    exposes `SEMGREP_APP_TOKEN` from repository secrets
+- Ran `./quality.sh` end-to-end: format check, lint, and 364 tests pass.

--- a/tests/semgrep_workflow_test.ts
+++ b/tests/semgrep_workflow_test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the Semgrep SAST Scanning workflow (#153).
+ *
+ * Validates that .github/workflows/semgrep.yml is present, parseable, and
+ * configured to scan pull requests inside the semgrep container with the
+ * required permissions.
+ */
+
+import { parse as parseYaml } from "@std/yaml";
+import { assert, assertEquals } from "./test_helpers.ts";
+
+const WORKFLOW_PATH = new URL(
+  "../.github/workflows/semgrep.yml",
+  import.meta.url,
+);
+
+interface SemgrepWorkflow {
+  name?: string;
+  on?: Record<string, unknown> | string;
+  permissions?: Record<string, string>;
+  jobs?: Record<string, {
+    "runs-on"?: string;
+    container?: string | { image?: string };
+    steps?: Array<{
+      uses?: string;
+      run?: string;
+      env?: Record<string, string>;
+    }>;
+  }>;
+}
+
+async function loadWorkflow(): Promise<SemgrepWorkflow> {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  return parseYaml(text) as SemgrepWorkflow;
+}
+
+Deno.test("semgrep workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, "expected semgrep.yml to be a regular file");
+});
+
+Deno.test("semgrep workflow is valid YAML and named correctly", async () => {
+  const wf = await loadWorkflow();
+  assertEquals(wf.name, "Semgrep");
+});
+
+Deno.test("semgrep workflow triggers on pull_request", async () => {
+  const wf = await loadWorkflow();
+  const triggers = wf.on as Record<string, unknown> | undefined;
+  assert(
+    triggers && typeof triggers === "object",
+    "workflow must declare triggers",
+  );
+  assert(
+    "pull_request" in triggers,
+    "workflow must trigger on pull_request events",
+  );
+});
+
+Deno.test("semgrep workflow uses minimal contents:read permissions", async () => {
+  const wf = await loadWorkflow();
+  assertEquals(wf.permissions?.contents, "read");
+});
+
+Deno.test("semgrep workflow runs in the semgrep container", async () => {
+  const wf = await loadWorkflow();
+  const job = wf.jobs?.semgrep;
+  assert(job, "expected a 'semgrep' job");
+  assertEquals(job!["runs-on"], "ubuntu-latest");
+
+  const container = job!.container;
+  const image = typeof container === "string" ? container : container?.image;
+  assertEquals(
+    image,
+    "semgrep/semgrep",
+    "job must run inside the semgrep/semgrep container image",
+  );
+});
+
+Deno.test("semgrep workflow checks out and runs semgrep ci", async () => {
+  const wf = await loadWorkflow();
+  const job = wf.jobs?.semgrep;
+  assert(job, "expected a 'semgrep' job");
+
+  const steps = job!.steps ?? [];
+  const checkout = steps.find((s) =>
+    (s.uses ?? "").startsWith("actions/checkout@")
+  );
+  assert(checkout, "workflow must check out the repository");
+
+  const scan = steps.find((s) => (s.run ?? "").includes("semgrep ci"));
+  assert(scan, "workflow must run a 'semgrep ci' step");
+  assert(
+    (scan!.run ?? "").includes("--config"),
+    "semgrep ci step must specify a --config ruleset",
+  );
+  assertEquals(
+    scan!.env?.SEMGREP_APP_TOKEN,
+    "${{ secrets.SEMGREP_APP_TOKEN }}",
+    "semgrep ci must receive SEMGREP_APP_TOKEN from repository secrets",
+  );
+});


### PR DESCRIPTION
## Summary

Added a Semgrep SAST scanning GitHub Actions workflow that runs on every pull
request, executing `semgrep ci --config p/default` inside the official
`semgrep/semgrep` container. This strengthens the repository's security posture
by catching common code-level vulnerabilities at PR review time. Closes #153.

## Evidence

This is a CI/workflow change with no UI surface. Verification was done via a new
Deno test suite (`tests/semgrep_workflow_test.ts`) that parses the workflow YAML
and asserts on its structure, and via the full quality gate.

```mermaid
flowchart LR
    A[Pull Request opened] --> B[GitHub Actions]
    B --> C[Semgrep container]
    C --> D[semgrep ci --config p/default]
    D --> E{Findings?}
    E -- yes --> F[Annotate PR / fail check]
    E -- no --> G[Pass]
```

Quality gate output:

```
ok | 364 passed | 0 failed (7s)
==> OK
```

## Test Plan

- Added `tests/semgrep_workflow_test.ts` with six checks covering:
  - File presence at `.github/workflows/semgrep.yml`
  - Valid YAML and `name: Semgrep`
  - `pull_request` trigger declared
  - Minimal `contents: read` permission
  - Job runs inside the `semgrep/semgrep` container on `ubuntu-latest`
  - Steps include `actions/checkout@` and a `semgrep ci --config ...` run that
    exposes `SEMGREP_APP_TOKEN` from repository secrets
- Ran `./quality.sh` end-to-end: format check, lint, and 364 tests pass.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-153 -->