### PR TITLE
Add ShellCheck Lint workflow (#156)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,21 @@
+name: ShellCheck
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Pinned to a commit SHA — the upstream template uses @master, which is
+      # a moving ref and a known supply-chain risk.
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca
+        with:
+          scandir: "."
+          severity: warning

--- a/docs/pr-summary-156.md
+++ b/docs/pr-summary-156.md
@@ -1,0 +1,47 @@
+## Summary
+
+Adds a ShellCheck Lint workflow at `.github/workflows/shellcheck.yml` that runs
+on every pull request. The workflow scans the repository's shell scripts
+(`quality.sh` and `helpers/server.sh`) at `severity: warning` using
+`ludeeus/action-shellcheck`.
+
+The third-party action is pinned to a commit SHA rather than the `@master` ref
+shown in the issue template — `@master` is a moving target and a documented
+supply-chain risk. Closes #156.
+
+## Evidence
+
+This is a CI-only change with no UI surface. Verified by:
+
+- **Local ShellCheck run** —
+  `shellcheck --severity=warning quality.sh helpers/server.sh` exits 0, so the
+  new gate will be green for the existing scripts.
+- **Workflow structure tests** — `tests/shellcheck_workflow_test.ts` parses the
+  YAML and asserts the trigger, permissions, job, action, severity, and pinning
+  rules.
+- **Quality gate** — `./quality.sh` passes with 370/370 tests.
+
+```mermaid
+flowchart LR
+    PR[Pull Request] --> CI[GitHub Actions]
+    CI --> SC[ShellCheck workflow]
+    SC --> Scan[ludeeus/action-shellcheck @ pinned SHA]
+    Scan --> Q[quality.sh]
+    Scan --> H[helpers/server.sh]
+    Q --> Result{Warnings?}
+    H --> Result
+    Result -- none --> Pass[PR check passes]
+    Result -- found --> Fail[PR check fails]
+```
+
+## Test Plan
+
+- Added `tests/shellcheck_workflow_test.ts` with six tests:
+  - workflow file exists
+  - YAML parses and `name: ShellCheck`
+  - triggers on `pull_request`
+  - `permissions.contents: read`
+  - job uses `actions/checkout` and `ludeeus/action-shellcheck` with
+    `severity: warning` and `scandir: .`
+  - third-party action is not pinned to `master`/`main`
+- Ran `./quality.sh` — all 370 tests pass, format and lint clean.

--- a/tests/shellcheck_workflow_test.ts
+++ b/tests/shellcheck_workflow_test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for the ShellCheck Lint workflow (#156).
+ *
+ * Validates that .github/workflows/shellcheck.yml is present, parseable, and
+ * configured to lint shell scripts on pull requests with the expected
+ * permissions and action invocation.
+ */
+
+import { parse as parseYaml } from "@std/yaml";
+import { assert, assertEquals } from "./test_helpers.ts";
+
+const WORKFLOW_PATH = new URL(
+  "../.github/workflows/shellcheck.yml",
+  import.meta.url,
+);
+
+interface ShellCheckWorkflow {
+  name?: string;
+  on?: Record<string, unknown> | string;
+  permissions?: Record<string, string>;
+  jobs?: Record<string, {
+    "runs-on"?: string;
+    steps?: Array<
+      { uses?: string; name?: string; with?: Record<string, unknown> }
+    >;
+  }>;
+}
+
+async function loadWorkflow(): Promise<ShellCheckWorkflow> {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  return parseYaml(text) as ShellCheckWorkflow;
+}
+
+Deno.test("shellcheck workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, "expected shellcheck.yml to be a regular file");
+});
+
+Deno.test("shellcheck workflow is valid YAML and named correctly", async () => {
+  const wf = await loadWorkflow();
+  assertEquals(wf.name, "ShellCheck");
+});
+
+Deno.test("shellcheck workflow triggers on pull_request", async () => {
+  const wf = await loadWorkflow();
+  const triggers = wf.on as Record<string, unknown> | undefined;
+  assert(
+    triggers && typeof triggers === "object",
+    "workflow must declare triggers",
+  );
+  assert(
+    "pull_request" in triggers,
+    "workflow must trigger on pull_request events",
+  );
+});
+
+Deno.test("shellcheck workflow uses minimal contents:read permissions", async () => {
+  const wf = await loadWorkflow();
+  assertEquals(wf.permissions?.contents, "read");
+});
+
+Deno.test("shellcheck workflow runs action-shellcheck at warning severity", async () => {
+  const wf = await loadWorkflow();
+  const job = wf.jobs?.shellcheck;
+  assert(job, "expected a 'shellcheck' job");
+  assertEquals(job!["runs-on"], "ubuntu-latest");
+
+  const steps = job!.steps ?? [];
+  const checkout = steps.find((s) =>
+    (s.uses ?? "").startsWith("actions/checkout@")
+  );
+  assert(checkout, "workflow must check out the repository");
+
+  const shellcheck = steps.find((s) =>
+    (s.uses ?? "").startsWith("ludeeus/action-shellcheck@")
+  );
+  assert(shellcheck, "workflow must run the ludeeus/action-shellcheck step");
+  assertEquals(
+    shellcheck!.with?.severity,
+    "warning",
+    "shellcheck must run at severity: warning",
+  );
+  assertEquals(
+    shellcheck!.with?.scandir,
+    ".",
+    "shellcheck must scan the repository root",
+  );
+});
+
+Deno.test("shellcheck workflow does not pin third-party action to a moving ref", async () => {
+  const wf = await loadWorkflow();
+  const job = wf.jobs?.shellcheck;
+  const steps = job?.steps ?? [];
+  const shellcheck = steps.find((s) =>
+    (s.uses ?? "").startsWith("ludeeus/action-shellcheck@")
+  );
+  assert(shellcheck, "workflow must run the ludeeus/action-shellcheck step");
+  const ref = (shellcheck!.uses ?? "").split("@")[1] ?? "";
+  assert(
+    ref !== "master" && ref !== "main",
+    `third-party action must be pinned to a tag or commit SHA, not ${ref}`,
+  );
+});


### PR DESCRIPTION
## Summary

Adds a ShellCheck Lint workflow at `.github/workflows/shellcheck.yml` that runs
on every pull request. The workflow scans the repository's shell scripts
(`quality.sh` and `helpers/server.sh`) at `severity: warning` using
`ludeeus/action-shellcheck`.

The third-party action is pinned to a commit SHA rather than the `@master` ref
shown in the issue template — `@master` is a moving target and a documented
supply-chain risk. Closes #156.

## Evidence

This is a CI-only change with no UI surface. Verified by:

- **Local ShellCheck run** —
  `shellcheck --severity=warning quality.sh helpers/server.sh` exits 0, so the
  new gate will be green for the existing scripts.
- **Workflow structure tests** — `tests/shellcheck_workflow_test.ts` parses the
  YAML and asserts the trigger, permissions, job, action, severity, and pinning
  rules.
- **Quality gate** — `./quality.sh` passes with 370/370 tests.

```mermaid
flowchart LR
    PR[Pull Request] --> CI[GitHub Actions]
    CI --> SC[ShellCheck workflow]
    SC --> Scan[ludeeus/action-shellcheck @ pinned SHA]
    Scan --> Q[quality.sh]
    Scan --> H[helpers/server.sh]
    Q --> Result{Warnings?}
    H --> Result
    Result -- none --> Pass[PR check passes]
    Result -- found --> Fail[PR check fails]
```

## Test Plan

- Added `tests/shellcheck_workflow_test.ts` with six tests:
  - workflow file exists
  - YAML parses and `name: ShellCheck`
  - triggers on `pull_request`
  - `permissions.contents: read`
  - job uses `actions/checkout` and `ludeeus/action-shellcheck` with
    `severity: warning` and `scandir: .`
  - third-party action is not pinned to `master`/`main`
- Ran `./quality.sh` — all 370 tests pass, format and lint clean.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-156 -->