### PR TITLE
Add Deno Dependency Updates workflow (#155)

### DIFF
--- a/.github/workflows/deno-outdated.yml
+++ b/.github/workflows/deno-outdated.yml
@@ -1,0 +1,37 @@
+name: Deno Dependency Updates
+
+on:
+  schedule:
+    # Mondays at 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  outdated:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.x
+
+      - name: Update Deno dependencies to latest
+        run: deno outdated --update --latest
+
+      - name: Open pull request with updates
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          commit-message: "chore: update Deno dependencies"
+          title: "chore: update Deno dependencies"
+          branch: chore/deno-outdated
+          body: |
+            Automated Deno dependency update via `deno outdated --update --latest`.
+
+            Raised by the weekly Deno Dependency Updates workflow (#155).

--- a/docs/pr-summary-155.md
+++ b/docs/pr-summary-155.md
@@ -1,0 +1,31 @@
+## Summary
+
+Added `.github/workflows/deno-outdated.yml`, a weekly GitHub Actions workflow that runs `deno outdated --update --latest` and opens a pull request with the resulting `deno.json` / `deno.lock` changes. This keeps the project on current Deno standard-library and third-party module versions without manual chasing. Closes #155.
+
+Third-party actions are pinned to commit SHAs (with the human-readable tag in a trailing comment) per the repository's supply-chain guidance.
+
+## Evidence
+
+CLI / workflow change — no UI to screenshot. Verified by:
+
+- New unit tests in `tests/deno_outdated_workflow_test.ts` parse the YAML and assert the schedule, permissions, and required steps.
+- `./quality.sh` passes cleanly (375 tests, 0 failures).
+
+```mermaid
+flowchart LR
+    A[Weekly cron / manual dispatch] --> B[Checkout repo]
+    B --> C[Setup Deno v2.x]
+    C --> D[deno outdated --update --latest]
+    D --> E[peter-evans/create-pull-request]
+    E --> F[PR on chore/deno-outdated]
+```
+
+## Test Plan
+
+- Added `tests/deno_outdated_workflow_test.ts` covering:
+  - workflow file exists and parses as YAML
+  - workflow is named "Deno Dependency Updates"
+  - triggers include a weekly `schedule` entry and `workflow_dispatch`
+  - `permissions` grants `contents: write` and `pull-requests: write`
+  - job runs checkout, `denoland/setup-deno`, `deno outdated --update --latest`, and `peter-evans/create-pull-request` with a branch
+- `./quality.sh < /dev/null` — passes (fmt, lint, full test suite).

--- a/docs/pr-summary-155.md
+++ b/docs/pr-summary-155.md
@@ -1,14 +1,20 @@
 ## Summary
 
-Added `.github/workflows/deno-outdated.yml`, a weekly GitHub Actions workflow that runs `deno outdated --update --latest` and opens a pull request with the resulting `deno.json` / `deno.lock` changes. This keeps the project on current Deno standard-library and third-party module versions without manual chasing. Closes #155.
+Added `.github/workflows/deno-outdated.yml`, a weekly GitHub Actions workflow
+that runs `deno outdated --update --latest` and opens a pull request with the
+resulting `deno.json` / `deno.lock` changes. This keeps the project on current
+Deno standard-library and third-party module versions without manual chasing.
+Closes #155.
 
-Third-party actions are pinned to commit SHAs (with the human-readable tag in a trailing comment) per the repository's supply-chain guidance.
+Third-party actions are pinned to commit SHAs (with the human-readable tag in a
+trailing comment) per the repository's supply-chain guidance.
 
 ## Evidence
 
 CLI / workflow change — no UI to screenshot. Verified by:
 
-- New unit tests in `tests/deno_outdated_workflow_test.ts` parse the YAML and assert the schedule, permissions, and required steps.
+- New unit tests in `tests/deno_outdated_workflow_test.ts` parse the YAML and
+  assert the schedule, permissions, and required steps.
 - `./quality.sh` passes cleanly (375 tests, 0 failures).
 
 ```mermaid
@@ -27,5 +33,6 @@ flowchart LR
   - workflow is named "Deno Dependency Updates"
   - triggers include a weekly `schedule` entry and `workflow_dispatch`
   - `permissions` grants `contents: write` and `pull-requests: write`
-  - job runs checkout, `denoland/setup-deno`, `deno outdated --update --latest`, and `peter-evans/create-pull-request` with a branch
+  - job runs checkout, `denoland/setup-deno`, `deno outdated --update --latest`,
+    and `peter-evans/create-pull-request` with a branch
 - `./quality.sh < /dev/null` — passes (fmt, lint, full test suite).

--- a/tests/deno_outdated_workflow_test.ts
+++ b/tests/deno_outdated_workflow_test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the Deno Dependency Updates workflow (#155).
+ *
+ * Validates that .github/workflows/deno-outdated.yml is present, parseable,
+ * and configured to run `deno outdated --update --latest` on a weekly
+ * schedule and open a pull request with the changes.
+ */
+
+import { parse as parseYaml } from "@std/yaml";
+import { assert, assertEquals } from "./test_helpers.ts";
+
+const WORKFLOW_PATH = new URL(
+  "../.github/workflows/deno-outdated.yml",
+  import.meta.url,
+);
+
+interface WorkflowStep {
+  uses?: string;
+  run?: string;
+  with?: Record<string, unknown>;
+}
+
+interface OutdatedWorkflow {
+  name?: string;
+  on?: Record<string, unknown> | string;
+  permissions?: Record<string, string>;
+  jobs?: Record<string, {
+    "runs-on"?: string;
+    steps?: WorkflowStep[];
+  }>;
+}
+
+async function loadWorkflow(): Promise<OutdatedWorkflow> {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  return parseYaml(text) as OutdatedWorkflow;
+}
+
+Deno.test("deno-outdated workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, "expected deno-outdated.yml to be a regular file");
+});
+
+Deno.test("deno-outdated workflow is valid YAML and named correctly", async () => {
+  const wf = await loadWorkflow();
+  assertEquals(wf.name, "Deno Dependency Updates");
+});
+
+Deno.test("deno-outdated workflow runs on a weekly schedule and on demand", async () => {
+  const wf = await loadWorkflow();
+  const triggers = wf.on as Record<string, unknown> | undefined;
+  assert(
+    triggers && typeof triggers === "object",
+    "workflow must declare triggers",
+  );
+  assert(
+    "schedule" in triggers,
+    "workflow must declare a schedule trigger",
+  );
+  assert(
+    "workflow_dispatch" in triggers,
+    "workflow must support manual workflow_dispatch",
+  );
+  const schedule = triggers.schedule as Array<{ cron?: string }>;
+  assert(
+    Array.isArray(schedule) && schedule.length > 0,
+    "schedule entry expected",
+  );
+  assert(
+    typeof schedule[0].cron === "string" && schedule[0].cron.length > 0,
+    "schedule must specify a cron expression",
+  );
+});
+
+Deno.test("deno-outdated workflow grants write permissions for PR creation", async () => {
+  const wf = await loadWorkflow();
+  assertEquals(wf.permissions?.contents, "write");
+  assertEquals(wf.permissions?.["pull-requests"], "write");
+});
+
+Deno.test("deno-outdated workflow checks out, sets up Deno, runs deno outdated, and opens a PR", async () => {
+  const wf = await loadWorkflow();
+  const job = wf.jobs?.outdated;
+  assert(job, "expected an 'outdated' job");
+  assertEquals(job!["runs-on"], "ubuntu-latest");
+
+  const steps = job!.steps ?? [];
+  const checkout = steps.find((s) =>
+    (s.uses ?? "").startsWith("actions/checkout@")
+  );
+  assert(checkout, "workflow must check out the repository");
+
+  const setupDeno = steps.find((s) =>
+    (s.uses ?? "").startsWith("denoland/setup-deno@")
+  );
+  assert(setupDeno, "workflow must set up Deno");
+
+  const outdated = steps.find((s) =>
+    typeof s.run === "string" && s.run.includes("deno outdated")
+  );
+  assert(outdated, "workflow must run `deno outdated`");
+  assert(
+    (outdated!.run ?? "").includes("--update"),
+    "deno outdated must use --update to apply updates",
+  );
+  assert(
+    (outdated!.run ?? "").includes("--latest"),
+    "deno outdated must use --latest to pull the newest versions",
+  );
+
+  const createPr = steps.find((s) =>
+    (s.uses ?? "").startsWith("peter-evans/create-pull-request@")
+  );
+  assert(createPr, "workflow must open a pull request with the updates");
+  const branch = createPr!.with?.branch;
+  assert(
+    typeof branch === "string" && branch.length > 0,
+    "create-pull-request step must specify a branch",
+  );
+});


### PR DESCRIPTION
## Summary

Added `.github/workflows/deno-outdated.yml`, a weekly GitHub Actions workflow that runs `deno outdated --update --latest` and opens a pull request with the resulting `deno.json` / `deno.lock` changes. This keeps the project on current Deno standard-library and third-party module versions without manual chasing. Closes #155.

Third-party actions are pinned to commit SHAs (with the human-readable tag in a trailing comment) per the repository's supply-chain guidance.

## Evidence

CLI / workflow change — no UI to screenshot. Verified by:

- New unit tests in `tests/deno_outdated_workflow_test.ts` parse the YAML and assert the schedule, permissions, and required steps.
- `./quality.sh` passes cleanly (375 tests, 0 failures).

```mermaid
flowchart LR
    A[Weekly cron / manual dispatch] --> B[Checkout repo]
    B --> C[Setup Deno v2.x]
    C --> D[deno outdated --update --latest]
    D --> E[peter-evans/create-pull-request]
    E --> F[PR on chore/deno-outdated]
```

## Test Plan

- Added `tests/deno_outdated_workflow_test.ts` covering:
  - workflow file exists and parses as YAML
  - workflow is named "Deno Dependency Updates"
  - triggers include a weekly `schedule` entry and `workflow_dispatch`
  - `permissions` grants `contents: write` and `pull-requests: write`
  - job runs checkout, `denoland/setup-deno`, `deno outdated --update --latest`, and `peter-evans/create-pull-request` with a branch
- `./quality.sh < /dev/null` — passes (fmt, lint, full test suite).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-155 -->