### PR TITLE
Pin gitleaks workflow actions and fetch PR base branch (#167)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -30,7 +30,9 @@ jobs:
       # NEAT-AI quality.yml pattern.
       - name: Fetch base branch
         if: github.event_name == 'pull_request'
-        run: git fetch origin "${{ github.base_ref }}:${{ github.base_ref }}" || true
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch origin "$BASE_REF:$BASE_REF" || true
       # gitleaks/gitleaks-action@v2.3.9
       - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
         env:

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,5 +1,12 @@
 name: Gitleaks
 
+# Detect secrets in pull request diffs using gitleaks-action.
+#
+# Mirrors the canonical NEAT-AI pattern at
+# stSoftwareAU/NEAT-AI/.github/workflows/quality.yml. Third-party
+# actions are pinned to 40-character commit SHAs (Issue #1756) so a
+# hijacked tag cannot exfiltrate CI secrets.
+
 on:
   pull_request:
     branches: ["*"]
@@ -11,10 +18,25 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      # Fetch the PR base branch so gitleaks-action's computed commit
+      # range (`<base_sha>^..<head_sha>`) resolves on the runner.
+      # Without this step the action fails with
+      # "fatal: Invalid revision range" because the base ref's parent
+      # is not in the shallow checkout (Issue #1756). Mirrors the
+      # NEAT-AI quality.yml pattern.
+      - name: Fetch base branch
+        if: github.event_name == 'pull_request'
+        run: git fetch origin "${{ github.base_ref }}:${{ github.base_ref }}" || true
+      # gitleaks/gitleaks-action@v2.3.9
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Org-level Gitleaks Pro licence (Issue #1636). Required for
+          # repos under stSoftwareAU/*; without it gitleaks-action exits
+          # with ErrLicense before scanning. Configure in repo or org
+          # secrets.
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/docs/pr-summary-167.md
+++ b/docs/pr-summary-167.md
@@ -1,15 +1,14 @@
 ## Summary
 
-Updated `.github/workflows/gitleaks.yml` to match the canonical NEAT-AI
-pattern: pinned `actions/checkout` and `gitleaks/gitleaks-action` to
-40-character commit SHAs (Issue #1756), and added a `Fetch base branch`
-step so gitleaks-action's `<base_sha>^..<head_sha>` range resolves on
-the runner. Closes #167.
+Updated `.github/workflows/gitleaks.yml` to match the canonical NEAT-AI pattern:
+pinned `actions/checkout` and `gitleaks/gitleaks-action` to 40-character commit
+SHAs (Issue #1756), and added a `Fetch base branch` step so gitleaks-action's
+`<base_sha>^..<head_sha>` range resolves on the runner. Closes #167.
 
 ## Evidence
 
-CLI-only change — no UI to screenshot. Verified by added unit tests
-exercising the workflow YAML directly (`tests/gitleaks_workflow_test.ts`).
+CLI-only change — no UI to screenshot. Verified by added unit tests exercising
+the workflow YAML directly (`tests/gitleaks_workflow_test.ts`).
 
 ```mermaid
 flowchart LR
@@ -30,11 +29,10 @@ ok | 393 passed | 0 failed (5s)
 
 ## Test Plan
 
-- Added `gitleaks workflow pins third-party actions to commit SHAs` —
-  asserts every `uses:` step ends in a 40-character hex SHA, so a
-  reviewer accidentally downgrading to a `@vN` tag fails CI.
-- Added `gitleaks workflow fetches PR base branch before scanning` —
-  asserts a `git fetch origin` step exists, is guarded by a
-  `pull_request` event check, and is ordered between the checkout and
-  gitleaks-action steps.
+- Added `gitleaks workflow pins third-party actions to commit SHAs` — asserts
+  every `uses:` step ends in a 40-character hex SHA, so a reviewer accidentally
+  downgrading to a `@vN` tag fails CI.
+- Added `gitleaks workflow fetches PR base branch before scanning` — asserts a
+  `git fetch origin` step exists, is guarded by a `pull_request` event check,
+  and is ordered between the checkout and gitleaks-action steps.
 - Existing five gitleaks workflow tests continue to pass unchanged.

--- a/docs/pr-summary-167.md
+++ b/docs/pr-summary-167.md
@@ -1,0 +1,40 @@
+## Summary
+
+Updated `.github/workflows/gitleaks.yml` to match the canonical NEAT-AI
+pattern: pinned `actions/checkout` and `gitleaks/gitleaks-action` to
+40-character commit SHAs (Issue #1756), and added a `Fetch base branch`
+step so gitleaks-action's `<base_sha>^..<head_sha>` range resolves on
+the runner. Closes #167.
+
+## Evidence
+
+CLI-only change — no UI to screenshot. Verified by added unit tests
+exercising the workflow YAML directly (`tests/gitleaks_workflow_test.ts`).
+
+```mermaid
+flowchart LR
+    A[PR opened] --> B[checkout @SHA<br/>fetch-depth: 0]
+    B --> C[Fetch base branch<br/>git fetch origin base_ref]
+    C --> D[gitleaks-action @SHA]
+    D --> E{Secret found?}
+    E -- yes --> F[Fail PR]
+    E -- no --> G[Pass]
+```
+
+Quality gate output:
+
+```
+ok | 393 passed | 0 failed (5s)
+==> OK
+```
+
+## Test Plan
+
+- Added `gitleaks workflow pins third-party actions to commit SHAs` —
+  asserts every `uses:` step ends in a 40-character hex SHA, so a
+  reviewer accidentally downgrading to a `@vN` tag fails CI.
+- Added `gitleaks workflow fetches PR base branch before scanning` —
+  asserts a `git fetch origin` step exists, is guarded by a
+  `pull_request` event check, and is ordered between the checkout and
+  gitleaks-action steps.
+- Existing five gitleaks workflow tests continue to pass unchanged.

--- a/tests/gitleaks_workflow_test.ts
+++ b/tests/gitleaks_workflow_test.ts
@@ -20,7 +20,13 @@ interface GitleaksWorkflow {
   permissions?: Record<string, string>;
   jobs?: Record<string, {
     "runs-on"?: string;
-    steps?: Array<{ uses?: string; with?: Record<string, unknown> }>;
+    steps?: Array<{
+      name?: string;
+      uses?: string;
+      run?: string;
+      if?: string;
+      with?: Record<string, unknown>;
+    }>;
   }>;
 }
 
@@ -78,4 +84,56 @@ Deno.test("gitleaks workflow runs gitleaks-action with full history", async () =
     (s.uses ?? "").startsWith("gitleaks/gitleaks-action@")
   );
   assert(gitleaks, "workflow must run the gitleaks/gitleaks-action step");
+});
+
+Deno.test("gitleaks workflow pins third-party actions to commit SHAs", async () => {
+  const wf = await loadWorkflow();
+  const steps = wf.jobs?.gitleaks?.steps ?? [];
+  const sha40 = /@[0-9a-f]{40}$/;
+  for (const step of steps) {
+    if (!step.uses) continue;
+    assert(
+      sha40.test(step.uses),
+      `step '${step.uses}' must be pinned to a 40-character commit SHA ` +
+        `(Issue #1756) — version tags are mutable and a hijacked tag can ` +
+        `exfiltrate CI secrets`,
+    );
+  }
+});
+
+Deno.test("gitleaks workflow fetches PR base branch before scanning", async () => {
+  const wf = await loadWorkflow();
+  const steps = wf.jobs?.gitleaks?.steps ?? [];
+
+  const fetchStep = steps.find((s) =>
+    typeof s.run === "string" && s.run.includes("git fetch origin")
+  );
+  assert(
+    fetchStep,
+    "workflow must fetch the PR base branch so gitleaks-action's commit " +
+      "range resolves on the runner (mirrors NEAT-AI quality.yml pattern)",
+  );
+  assert(
+    typeof fetchStep!.if === "string" &&
+      fetchStep!.if.includes("pull_request"),
+    "fetch-base-branch step must be guarded by a pull_request event check",
+  );
+
+  // Order matters: the fetch must run after checkout but before gitleaks.
+  const indexOf = (
+    predicate: (s: { uses?: string; run?: string }) => boolean,
+  ) => steps.findIndex(predicate);
+  const checkoutIdx = indexOf((s) =>
+    (s.uses ?? "").startsWith("actions/checkout@")
+  );
+  const fetchIdx = indexOf((s) =>
+    typeof s.run === "string" && s.run.includes("git fetch origin")
+  );
+  const gitleaksIdx = indexOf((s) =>
+    (s.uses ?? "").startsWith("gitleaks/gitleaks-action@")
+  );
+  assert(
+    checkoutIdx < fetchIdx && fetchIdx < gitleaksIdx,
+    "fetch step must run after checkout and before gitleaks-action",
+  );
 });


### PR DESCRIPTION
## Summary

Updated `.github/workflows/gitleaks.yml` to match the canonical NEAT-AI
pattern: pinned `actions/checkout` and `gitleaks/gitleaks-action` to
40-character commit SHAs (Issue #1756), and added a `Fetch base branch`
step so gitleaks-action's `<base_sha>^..<head_sha>` range resolves on
the runner. Closes #167.

## Evidence

CLI-only change — no UI to screenshot. Verified by added unit tests
exercising the workflow YAML directly (`tests/gitleaks_workflow_test.ts`).

```mermaid
flowchart LR
    A[PR opened] --> B[checkout @SHA<br/>fetch-depth: 0]
    B --> C[Fetch base branch<br/>git fetch origin base_ref]
    C --> D[gitleaks-action @SHA]
    D --> E{Secret found?}
    E -- yes --> F[Fail PR]
    E -- no --> G[Pass]
```

Quality gate output:

```
ok | 393 passed | 0 failed (5s)
==> OK
```

## Test Plan

- Added `gitleaks workflow pins third-party actions to commit SHAs` —
  asserts every `uses:` step ends in a 40-character hex SHA, so a
  reviewer accidentally downgrading to a `@vN` tag fails CI.
- Added `gitleaks workflow fetches PR base branch before scanning` —
  asserts a `git fetch origin` step exists, is guarded by a
  `pull_request` event check, and is ordered between the checkout and
  gitleaks-action steps.
- Existing five gitleaks workflow tests continue to pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)