### PR TITLE
Add Markdown Lint workflow (Issue #170)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,25 @@
+name: Markdown Lint
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [main, master, Develop]
+
+permissions:
+  contents: read
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "lts/*"
+      - name: Install markdownlint-cli2
+        run: npm install -g markdownlint-cli2
+      - name: Run markdownlint-cli2
+        run: markdownlint-cli2

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 !.gitignore
 !.gitattributes
 !.github
+!.markdownlint-cli2.jsonc
 
 # Python build artefacts (local tooling only)
 __pycache__/

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,26 @@
+// Markdown lint configuration for NEAT-AI Explore (Issue #170).
+//
+// Notes:
+// - MD013 (line-length) is disabled — prose and tables in this repo wrap to
+//   readable widths in the editor and CI does not need to enforce a column
+//   limit on Markdown.
+// - MD041 (first-line-h1) is disabled — generated PR-summary documents under
+//   docs/ start with `## Summary` rather than a top-level heading.
+// - Auto-generated PR-summary files and the historical archive are excluded
+//   so that legacy formatting does not block new PRs. The lint applies to
+//   README.md and any other authored docs added in future.
+{
+  "config": {
+    "default": true,
+    "MD013": false,
+    "MD041": false
+  },
+  "globs": [
+    "**/*.md"
+  ],
+  "ignores": [
+    "docs/archive/**",
+    "docs/pr-summary-*.md",
+    "node_modules/**"
+  ]
+}

--- a/docs/pr-summary-170.md
+++ b/docs/pr-summary-170.md
@@ -1,0 +1,56 @@
+## Summary
+
+Adds a Markdown Lint GitHub Actions workflow plus a repository
+`markdownlint-cli2` configuration so authored Markdown is checked on every pull
+request. Closes #170.
+
+The workflow installs `markdownlint-cli2` on Node LTS and runs it from the
+repository root. Third-party actions (`actions/checkout`, `actions/setup-node`)
+are pinned to 40-character commit SHAs in line with the supply-chain rules in
+`CLAUDE.md`. The optional Deno/Mermaid validation step from the upstream
+template is omitted because this repository has no `worker/deno/mod.ts`.
+
+The `.markdownlint-cli2.jsonc` config:
+
+- Disables `MD013` (line length) — too noisy for prose-heavy READMEs.
+- Disables `MD041` (first-line H1) — generated PR-summary files start with
+  `## Summary`.
+- Ignores `docs/archive/**` and `docs/pr-summary-*.md` so the legacy and
+  worker-generated files do not block new PRs. The lint applies to `README.md`
+  and any new authored Markdown.
+
+## Evidence
+
+CLI-only change. Verified locally:
+
+```text
+$ markdownlint-cli2
+Finding: **/*.md !docs/archive/** !docs/pr-summary-*.md !node_modules/**
+Linting: 1 file(s)
+Summary: 0 error(s)
+```
+
+`./quality.sh` passes with **400 tests, 0 failures**.
+
+```mermaid
+flowchart LR
+    PR[Pull Request] --> WF[Markdown Lint workflow]
+    WF --> N[setup-node @ pinned SHA]
+    N --> I[npm i -g markdownlint-cli2]
+    I --> R[markdownlint-cli2]
+    R -->|reads| C[.markdownlint-cli2.jsonc]
+    R --> Pass[CI green]
+```
+
+## Test Plan
+
+- Added `tests/markdown_lint_workflow_test.ts` covering:
+  - Workflow file exists and is valid YAML.
+  - `name` is `Markdown Lint`.
+  - Triggers include `pull_request` and `push`.
+  - Permissions limited to `contents: read`.
+  - Job runs on `ubuntu-latest`, checks out, sets up Node, installs and invokes
+    `markdownlint-cli2`.
+  - All `uses:` actions are pinned to 40-character commit SHAs.
+  - `.markdownlint-cli2.jsonc` exists and parses as JSON.
+- All 400 unit tests pass under `./quality.sh`.

--- a/tests/markdown_lint_workflow_test.ts
+++ b/tests/markdown_lint_workflow_test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for the Markdown Lint workflow (#170).
+ *
+ * Validates that .github/workflows/markdown-lint.yml is present, parseable,
+ * and configured to lint Markdown files on pull requests using
+ * markdownlint-cli2 with third-party actions pinned to commit SHAs.
+ */
+
+import { parse as parseYaml } from "@std/yaml";
+import { assert, assertEquals } from "./test_helpers.ts";
+
+const WORKFLOW_PATH = new URL(
+  "../.github/workflows/markdown-lint.yml",
+  import.meta.url,
+);
+const CONFIG_PATH = new URL(
+  "../.markdownlint-cli2.jsonc",
+  import.meta.url,
+);
+
+interface WorkflowStep {
+  uses?: string;
+  name?: string;
+  run?: string;
+  with?: Record<string, unknown>;
+  if?: string;
+  id?: string;
+}
+
+interface MarkdownLintWorkflow {
+  name?: string;
+  on?: Record<string, unknown> | string;
+  permissions?: Record<string, string>;
+  jobs?: Record<string, {
+    "runs-on"?: string;
+    steps?: WorkflowStep[];
+  }>;
+}
+
+async function loadWorkflow(): Promise<MarkdownLintWorkflow> {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  return parseYaml(text) as MarkdownLintWorkflow;
+}
+
+Deno.test("markdown-lint workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, "expected markdown-lint.yml to be a regular file");
+});
+
+Deno.test("markdown-lint workflow is valid YAML and named correctly", async () => {
+  const wf = await loadWorkflow();
+  assertEquals(wf.name, "Markdown Lint");
+});
+
+Deno.test("markdown-lint workflow triggers on pull_request and main pushes", async () => {
+  const wf = await loadWorkflow();
+  const triggers = wf.on as Record<string, unknown> | undefined;
+  assert(
+    triggers && typeof triggers === "object",
+    "workflow must declare triggers",
+  );
+  assert(
+    "pull_request" in triggers,
+    "workflow must trigger on pull_request events",
+  );
+  assert(
+    "push" in triggers,
+    "workflow must trigger on push events for the default branch",
+  );
+});
+
+Deno.test("markdown-lint workflow uses minimal contents:read permissions", async () => {
+  const wf = await loadWorkflow();
+  assertEquals(wf.permissions?.contents, "read");
+});
+
+Deno.test("markdown-lint workflow installs and runs markdownlint-cli2", async () => {
+  const wf = await loadWorkflow();
+  const job = wf.jobs?.markdownlint;
+  assert(job, "expected a 'markdownlint' job");
+  assertEquals(job!["runs-on"], "ubuntu-latest");
+
+  const steps = job!.steps ?? [];
+  const checkout = steps.find((s) =>
+    (s.uses ?? "").startsWith("actions/checkout@")
+  );
+  assert(checkout, "workflow must check out the repository");
+
+  const setupNode = steps.find((s) =>
+    (s.uses ?? "").startsWith("actions/setup-node@")
+  );
+  assert(setupNode, "workflow must set up Node.js");
+
+  const install = steps.find((s) =>
+    (s.run ?? "").includes("markdownlint-cli2")
+  );
+  assert(install, "workflow must install or run markdownlint-cli2");
+
+  const runStep = steps.find((s) =>
+    (s.run ?? "").trim() === "markdownlint-cli2" ||
+    (s.run ?? "").startsWith("markdownlint-cli2")
+  );
+  assert(runStep, "workflow must invoke markdownlint-cli2");
+});
+
+Deno.test("markdown-lint workflow pins third-party actions to commit SHAs", async () => {
+  const wf = await loadWorkflow();
+  const job = wf.jobs?.markdownlint;
+  const steps = job?.steps ?? [];
+
+  const thirdPartyUses = steps
+    .map((s) => s.uses ?? "")
+    .filter((u) => u.length > 0);
+
+  for (const uses of thirdPartyUses) {
+    const ref = uses.split("@")[1] ?? "";
+    // Commit SHAs are 40 hex characters; tags/branches are not.
+    assert(
+      /^[0-9a-f]{40}$/.test(ref),
+      `action ${uses} must be pinned to a 40-char commit SHA, got '${ref}'`,
+    );
+  }
+});
+
+Deno.test("markdownlint-cli2 config exists and is valid JSON", async () => {
+  const text = await Deno.readTextFile(CONFIG_PATH);
+  // Strip simple // line comments for JSONC parsing.
+  const stripped = text.replace(/^\s*\/\/.*$/gm, "");
+  const parsed = JSON.parse(stripped);
+  assert(
+    parsed && typeof parsed === "object",
+    "markdownlint-cli2 config must be a JSON object",
+  );
+});


### PR DESCRIPTION
## Summary

Adds a Markdown Lint GitHub Actions workflow plus a repository
`markdownlint-cli2` configuration so authored Markdown is checked on every pull
request. Closes #170.

The workflow installs `markdownlint-cli2` on Node LTS and runs it from the
repository root. Third-party actions (`actions/checkout`, `actions/setup-node`)
are pinned to 40-character commit SHAs in line with the supply-chain rules in
`CLAUDE.md`. The optional Deno/Mermaid validation step from the upstream
template is omitted because this repository has no `worker/deno/mod.ts`.

The `.markdownlint-cli2.jsonc` config:

- Disables `MD013` (line length) — too noisy for prose-heavy READMEs.
- Disables `MD041` (first-line H1) — generated PR-summary files start with
  `## Summary`.
- Ignores `docs/archive/**` and `docs/pr-summary-*.md` so the legacy and
  worker-generated files do not block new PRs. The lint applies to `README.md`
  and any new authored Markdown.

## Evidence

CLI-only change. Verified locally:

```text
$ markdownlint-cli2
Finding: **/*.md !docs/archive/** !docs/pr-summary-*.md !node_modules/**
Linting: 1 file(s)
Summary: 0 error(s)
```

`./quality.sh` passes with **400 tests, 0 failures**.

```mermaid
flowchart LR
    PR[Pull Request] --> WF[Markdown Lint workflow]
    WF --> N[setup-node @ pinned SHA]
    N --> I[npm i -g markdownlint-cli2]
    I --> R[markdownlint-cli2]
    R -->|reads| C[.markdownlint-cli2.jsonc]
    R --> Pass[CI green]
```

## Test Plan

- Added `tests/markdown_lint_workflow_test.ts` covering:
  - Workflow file exists and is valid YAML.
  - `name` is `Markdown Lint`.
  - Triggers include `pull_request` and `push`.
  - Permissions limited to `contents: read`.
  - Job runs on `ubuntu-latest`, checks out, sets up Node, installs and invokes
    `markdownlint-cli2`.
  - All `uses:` actions are pinned to 40-character commit SHAs.
  - `.markdownlint-cli2.jsonc` exists and parses as JSON.
- All 400 unit tests pass under `./quality.sh`.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-170 -->