### PR TITLE
Add Deno Lint and Format workflow (Issue #172)

### DIFF
--- a/.github/workflows/deno-quality.yml
+++ b/.github/workflows/deno-quality.yml
@@ -1,0 +1,37 @@
+name: Deno Quality
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      # denoland/setup-deno@v2.0.4
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+        with:
+          deno-version: v2.x
+      - name: Format check
+        run: deno fmt --check
+      - name: Lint
+        run: deno lint
+      - name: Type check
+        run: deno check helpers/ scripts/ tests/
+      # Run tests with coverage and upload to Codecov (Issue #1636).
+      # The codecov-action is a no-op when no test files are found.
+      - name: Tests with coverage
+        run: deno test -A --coverage=cov_profile
+      - name: Generate lcov coverage report
+        run: deno coverage cov_profile --lcov --output=coverage.lcov
+      # codecov/codecov-action@v5.5.4
+      - uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695
+        with:
+          files: coverage.lcov
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/docs/pr-summary-172.md
+++ b/docs/pr-summary-172.md
@@ -1,0 +1,61 @@
+## Summary
+
+Added the `Deno Quality` GitHub Actions workflow at
+`.github/workflows/deno-quality.yml` so every pull request — regardless of
+target branch — runs `deno fmt --check`, `deno lint`, `deno check`, and
+`deno test` with coverage uploaded to Codecov. The existing `Quality Gate`
+(`ci.yml`) only runs on PRs targeting `Develop`; this new workflow extends the
+same checks to feature-branch PRs and adds Codecov coverage reporting,
+addressing the VibeCoding workflow auditor's `deno-quality` sync. Closes #172.
+
+Third-party actions are pinned to 40-character commit SHAs per the project's
+supply-chain policy:
+
+- `actions/checkout@v5.0.1` → `93cb6efe18208431cddfb8368fd83d5badbf9bfd`
+- `denoland/setup-deno@v2.0.4` → `667a34cdef165d8d2b2e98dde39547c9daac7282`
+- `codecov/codecov-action@v5.5.4` → `aa56896cf108bd10b5eb883cd1d24196da57f695`
+
+The type-check step targets `helpers/ scripts/ tests/` (matching `quality.sh`)
+because this repository has no `mod.ts` — the ASCII web viewer ships as static
+files under `docs/`.
+
+## Evidence
+
+This is a CI/workflow change with no UI surface to screenshot. `./quality.sh`
+passes locally:
+
+```
+ok | 411 passed | 0 failed (1s)
+==> OK
+```
+
+The new workflow is exercised by 11 assertions in
+`tests/deno_quality_workflow_test.ts` covering existence, YAML validity, trigger
+configuration, permissions, all four Deno quality steps, coverage generation,
+Codecov upload, and SHA pinning.
+
+```mermaid
+flowchart LR
+    PR[Pull Request] --> WF[deno-quality.yml]
+    WF --> FMT[deno fmt --check]
+    WF --> LINT[deno lint]
+    WF --> CHECK[deno check]
+    WF --> TEST[deno test --coverage]
+    TEST --> LCOV[deno coverage --lcov]
+    LCOV --> CC[Codecov upload]
+```
+
+## Test Plan
+
+- Added `tests/deno_quality_workflow_test.ts` with 11 assertions:
+  - workflow file exists and parses as YAML
+  - name is `Deno Quality`
+  - triggers on `pull_request`
+  - declares `contents: read` permissions
+  - sets up Deno via `denoland/setup-deno`
+  - runs `deno fmt --check`, `deno lint`, `deno check`, `deno test --coverage`
+  - generates lcov output via `deno coverage --lcov`
+  - uploads via `codecov/codecov-action`
+  - pins all `uses:` steps to 40-char commit SHAs
+- Verified all tests fail before the workflow file is added and pass after.
+- Ran the full `./quality.sh` gate: 411 tests pass, fmt/lint/type-check clean.

--- a/tests/deno_quality_workflow_test.ts
+++ b/tests/deno_quality_workflow_test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for the Deno Quality workflow (#172).
+ *
+ * Validates that .github/workflows/deno-quality.yml exists, parses cleanly,
+ * triggers on pull requests for any branch, runs `deno fmt --check`,
+ * `deno lint`, `deno check`, and `deno test`, uploads coverage to Codecov,
+ * and pins all third-party actions to commit SHAs.
+ */
+
+import { parse as parseYaml } from "@std/yaml";
+import { assert, assertEquals } from "./test_helpers.ts";
+
+const WORKFLOW_PATH = new URL(
+  "../.github/workflows/deno-quality.yml",
+  import.meta.url,
+);
+
+interface WorkflowStep {
+  uses?: string;
+  name?: string;
+  run?: string;
+  with?: Record<string, unknown>;
+}
+
+interface DenoQualityWorkflow {
+  name?: string;
+  on?: Record<string, unknown> | string;
+  permissions?: Record<string, string>;
+  jobs?: Record<string, {
+    "runs-on"?: string;
+    steps?: WorkflowStep[];
+  }>;
+}
+
+async function loadWorkflow(): Promise<DenoQualityWorkflow> {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  return parseYaml(text) as DenoQualityWorkflow;
+}
+
+function findRunStep(
+  steps: WorkflowStep[],
+  needle: string,
+): WorkflowStep | undefined {
+  return steps.find((s) =>
+    typeof s.run === "string" && s.run!.includes(needle)
+  );
+}
+
+Deno.test("deno-quality workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, "expected deno-quality.yml to be a regular file");
+});
+
+Deno.test("deno-quality workflow is valid YAML and named correctly", async () => {
+  const wf = await loadWorkflow();
+  assertEquals(wf.name, "Deno Quality");
+});
+
+Deno.test("deno-quality workflow triggers on pull_request for any branch", async () => {
+  const wf = await loadWorkflow();
+  const triggers = wf.on as Record<string, unknown> | undefined;
+  assert(
+    triggers && typeof triggers === "object",
+    "workflow must declare triggers",
+  );
+  assert(
+    "pull_request" in triggers,
+    "workflow must trigger on pull_request events",
+  );
+});
+
+Deno.test("deno-quality workflow uses minimal contents:read permissions", async () => {
+  const wf = await loadWorkflow();
+  assertEquals(wf.permissions?.contents, "read");
+});
+
+Deno.test("deno-quality workflow sets up Deno via denoland/setup-deno", async () => {
+  const wf = await loadWorkflow();
+  const job = wf.jobs?.quality;
+  assert(job, "expected a 'quality' job");
+  const steps = job?.steps ?? [];
+  const setup = steps.find((s) =>
+    (s.uses ?? "").startsWith("denoland/setup-deno@")
+  );
+  assert(setup, "workflow must use denoland/setup-deno");
+});
+
+Deno.test("deno-quality workflow runs deno fmt --check", async () => {
+  const wf = await loadWorkflow();
+  const job = wf.jobs?.quality;
+  assert(job, "expected a 'quality' job");
+  const steps = job!.steps ?? [];
+  const fmt = findRunStep(steps, "deno fmt --check");
+  assert(fmt, "workflow must run 'deno fmt --check'");
+});
+
+Deno.test("deno-quality workflow runs deno lint", async () => {
+  const wf = await loadWorkflow();
+  const job = wf.jobs?.quality;
+  assert(job, "expected a 'quality' job");
+  const steps = job!.steps ?? [];
+  const lint = findRunStep(steps, "deno lint");
+  assert(lint, "workflow must run 'deno lint'");
+});
+
+Deno.test("deno-quality workflow runs deno check for type checking", async () => {
+  const wf = await loadWorkflow();
+  const job = wf.jobs?.quality;
+  assert(job, "expected a 'quality' job");
+  const steps = job!.steps ?? [];
+  const check = findRunStep(steps, "deno check");
+  assert(check, "workflow must run 'deno check'");
+});
+
+Deno.test("deno-quality workflow runs deno test with coverage", async () => {
+  const wf = await loadWorkflow();
+  const job = wf.jobs?.quality;
+  assert(job, "expected a 'quality' job");
+  const steps = job!.steps ?? [];
+  const test = findRunStep(steps, "deno test");
+  assert(test, "workflow must run 'deno test'");
+  assert(
+    test!.run!.includes("--coverage"),
+    "deno test must capture coverage data",
+  );
+});
+
+Deno.test("deno-quality workflow generates lcov coverage and uploads to Codecov", async () => {
+  const wf = await loadWorkflow();
+  const job = wf.jobs?.quality;
+  const steps = job?.steps ?? [];
+
+  const lcov = findRunStep(steps, "deno coverage");
+  assert(lcov, "workflow must convert coverage data to lcov format");
+  assert(
+    lcov!.run!.includes("--lcov"),
+    "deno coverage must emit lcov output",
+  );
+
+  const codecov = steps.find((s) =>
+    (s.uses ?? "").startsWith("codecov/codecov-action@")
+  );
+  assert(codecov, "workflow must upload coverage via codecov-action");
+});
+
+Deno.test("deno-quality workflow pins third-party actions to commit SHAs", async () => {
+  const wf = await loadWorkflow();
+  const job = wf.jobs?.quality;
+  const steps = job?.steps ?? [];
+
+  const thirdPartyUses = steps
+    .map((s) => s.uses ?? "")
+    .filter((u) => u.length > 0);
+
+  assert(thirdPartyUses.length > 0, "expected at least one 'uses:' step");
+
+  for (const uses of thirdPartyUses) {
+    const ref = uses.split("@")[1] ?? "";
+    assert(
+      /^[0-9a-f]{40}$/.test(ref),
+      `action ${uses} must be pinned to a 40-char commit SHA, got '${ref}'`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Added the `Deno Quality` GitHub Actions workflow at
`.github/workflows/deno-quality.yml` so every pull request — regardless of
target branch — runs `deno fmt --check`, `deno lint`, `deno check`, and
`deno test` with coverage uploaded to Codecov. The existing `Quality Gate`
(`ci.yml`) only runs on PRs targeting `Develop`; this new workflow extends the
same checks to feature-branch PRs and adds Codecov coverage reporting,
addressing the VibeCoding workflow auditor's `deno-quality` sync. Closes #172.

Third-party actions are pinned to 40-character commit SHAs per the project's
supply-chain policy:

- `actions/checkout@v5.0.1` → `93cb6efe18208431cddfb8368fd83d5badbf9bfd`
- `denoland/setup-deno@v2.0.4` → `667a34cdef165d8d2b2e98dde39547c9daac7282`
- `codecov/codecov-action@v5.5.4` → `aa56896cf108bd10b5eb883cd1d24196da57f695`

The type-check step targets `helpers/ scripts/ tests/` (matching `quality.sh`)
because this repository has no `mod.ts` — the ASCII web viewer ships as static
files under `docs/`.

## Evidence

This is a CI/workflow change with no UI surface to screenshot. `./quality.sh`
passes locally:

```
ok | 411 passed | 0 failed (1s)
==> OK
```

The new workflow is exercised by 11 assertions in
`tests/deno_quality_workflow_test.ts` covering existence, YAML validity, trigger
configuration, permissions, all four Deno quality steps, coverage generation,
Codecov upload, and SHA pinning.

```mermaid
flowchart LR
    PR[Pull Request] --> WF[deno-quality.yml]
    WF --> FMT[deno fmt --check]
    WF --> LINT[deno lint]
    WF --> CHECK[deno check]
    WF --> TEST[deno test --coverage]
    TEST --> LCOV[deno coverage --lcov]
    LCOV --> CC[Codecov upload]
```

## Test Plan

- Added `tests/deno_quality_workflow_test.ts` with 11 assertions:
  - workflow file exists and parses as YAML
  - name is `Deno Quality`
  - triggers on `pull_request`
  - declares `contents: read` permissions
  - sets up Deno via `denoland/setup-deno`
  - runs `deno fmt --check`, `deno lint`, `deno check`, `deno test --coverage`
  - generates lcov output via `deno coverage --lcov`
  - uploads via `codecov/codecov-action`
  - pins all `uses:` steps to 40-char commit SHAs
- Verified all tests fail before the workflow file is added and pass after.
- Ran the full `./quality.sh` gate: 411 tests pass, fmt/lint/type-check clean.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-172 -->