### PR TITLE
Reinforce multi-hop observation attribution walk for output neurons (#185)

### DIFF
--- a/docs/pr-summary-185.md
+++ b/docs/pr-summary-185.md
@@ -1,0 +1,66 @@
+# Reinforce multi-hop observation attribution walk for output neurons
+
+## Summary
+
+Reinforces `computeTopContributingInputs` in `docs/shared/graph_analysis.js` so
+it provably sums contribution share across all upstream paths when called from
+an output neuron, and hardens the test suite to cover branching, cycle and depth
+edge cases. Closes #185.
+
+Concretely:
+
+- Added an explicit **back-edge skip** during the upstream walk. Before
+  enqueuing an inbound predecessor we check whether it already appears on the
+  current walk's path; if so the edge is a back-edge and is skipped. This
+  guarantees termination on recurrent graphs while still allowing the same
+  neuron to be attributed along _different_ acyclic paths — which is exactly
+  what "sum across all upstream paths" requires.
+- Added a doc-comment block to `computeTopContributingInputs` describing the
+  chosen cycle-handling mechanism.
+- Added an `exhaustive` option that relaxes the per-node fan-out cap, the global
+  work cap, the depth cap and the frontier-queue cap. It is intended for the
+  small number of output-neuron callers (the consumer in issue #183) and leaves
+  defaults unchanged for every other caller.
+
+## Evidence
+
+This is a backend / pure-module change with no UI surface. Verified via the test
+suite (see Test Plan). Behaviour for non-output callers is explicitly pinned by
+`observation contributions: default behaviour is
+unchanged for non-output callers`.
+
+```mermaid
+flowchart LR
+    F[focus = output neuron] --> A[hidden-A]
+    F --> B[hidden-B]
+    A --> X[input-shared]
+    B --> X
+    A -. back-edge .-> B
+    B -. back-edge .-> A
+```
+
+Walks starting from `F` visit `input-shared` via both `A` and `B` and their
+normalised shares sum to 1. The dashed back-edges are detected by the
+path-membership check and never followed, so the walk terminates.
+
+## Test Plan
+
+Added `tests/observation_contributions_test.ts` covering:
+
+- Multiple paths to the same input sum correctly.
+- Cycles produce a finite, deterministic result (and complete well under a 2 s
+  budget).
+- Deep chains (depth 5) still reach the input.
+- Output neurons with only direct input edges attribute 100% across those inputs
+  (each input getting an equal third in the test case).
+- `exhaustive: true` reaches a 60-wide fan-out that the default
+  `maxInboundPerNode: 40` cap would otherwise truncate.
+- Default behaviour for non-output callers is unchanged (regression guard
+  against the new `exhaustive` defaults).
+
+The existing `tests/attribution_walk_test.ts` continues to pass — verifying the
+original two-hop attribution example is unaffected.
+
+Quality gate:
+
+- `./quality.sh < /dev/null` — 441 passed / 0 failed.

--- a/docs/shared/graph_analysis.js
+++ b/docs/shared/graph_analysis.js
@@ -87,12 +87,37 @@ export function computeReachableToOutputs({ outputUuids, incomingByTo }) {
  * This is designed for *large* creatures: it explores the highest-share inbound
  * branches first and caps work so it remains usable on iPhone.
  *
+ * Cycle handling
+ * --------------
+ * The walk is a best-first traversal upstream from `focusUuid`. Each queued
+ * frontier item carries its own `path` array — the chain of neurons from the
+ * currently-explored node back up to `focusUuid`. Before enqueuing an inbound
+ * predecessor we check whether that predecessor already appears on the
+ * current path; if it does, the edge is a back-edge and we skip it.
+ *
+ * This is equivalent to "visit each `(neuron, depth)` pair on a given walk at
+ * most once and skip back-edges": a neuron may still be attributed multiple
+ * times along *different* (acyclic) paths — which is what summing
+ * contribution share across all upstream paths requires — but a single walk
+ * never revisits a neuron it has already passed through. Combined with
+ * `maxDepth`, this guarantees termination on any graph, including recurrent
+ * networks.
+ *
+ * Output-neuron callers
+ * ---------------------
+ * Snapshots typically have a small number of output neurons, so we can
+ * afford to be more thorough when the focus is an output. Pass
+ * `exhaustive: true` to relax the per-node fan-out cap, the global work cap,
+ * the depth cap and the frontier-queue cap. The defaults are kept identical
+ * to the previous behaviour for all other callers.
+ *
  * @param {{
  *   focusUuid: string,
  *   getInboundEdges: (toUuid: string) => Edge[],
  *   maxDepth?: number,
  *   maxWork?: number,
  *   maxInboundPerNode?: number,
+ *   exhaustive?: boolean,
  * }} input
  * @returns {{
  *   focusUuid: string,
@@ -103,12 +128,22 @@ export function computeReachableToOutputs({ outputUuids, incomingByTo }) {
 export function computeTopContributingInputs(input) {
   const focusUuid = input?.focusUuid ?? "";
   const getInboundEdges = input?.getInboundEdges;
-  const maxDepth = Math.max(1, Math.floor(input?.maxDepth ?? 7));
-  const maxWork = Math.max(50, Math.floor(input?.maxWork ?? 1600));
+  const exhaustive = input?.exhaustive === true;
+  const maxDepth = Math.max(
+    1,
+    Math.floor(input?.maxDepth ?? (exhaustive ? 32 : 7)),
+  );
+  const maxWork = Math.max(
+    50,
+    Math.floor(input?.maxWork ?? (exhaustive ? 100000 : 1600)),
+  );
   const maxInboundPerNode = Math.max(
     5,
-    Math.floor(input?.maxInboundPerNode ?? 40),
+    Math.floor(
+      input?.maxInboundPerNode ?? (exhaustive ? Number.MAX_SAFE_INTEGER : 40),
+    ),
   );
+  const queueCap = exhaustive ? 5000 : 300;
 
   if (!focusUuid || typeof getInboundEdges !== "function") {
     return { focusUuid: focusUuid ?? "", inputs: [], truncated: false };
@@ -137,7 +172,7 @@ export function computeTopContributingInputs(input) {
     queue.push(item);
     // Simple bounded priority queue by score (descending).
     queue.sort((a, b) => b.score - a.score);
-    if (queue.length > 300) queue.length = 300;
+    if (queue.length > queueCap) queue.length = queueCap;
   }
 
   while (queue.length > 0) {
@@ -188,6 +223,10 @@ export function computeTopContributingInputs(input) {
       const nextUuid = s.fromUuid;
       const nextScore = cur.score * (s.share ?? 0);
       if (nextScore <= 0) continue;
+      // Skip back-edges: if `nextUuid` is already on this walk's path, the
+      // edge would close a cycle. Other walks may still attribute through
+      // `nextUuid` along different paths.
+      if (cur.path.includes(nextUuid)) continue;
       const nextPath = [nextUuid].concat(cur.path);
       push({
         uuid: nextUuid,

--- a/tests/observation_contributions_test.ts
+++ b/tests/observation_contributions_test.ts
@@ -1,0 +1,313 @@
+/**
+ * Multi-hop observation attribution walk tests for output neurons.
+ *
+ * Reinforces the contract expected by issue #185: when
+ * `computeTopContributingInputs` is called for an output neuron it must sum
+ * contribution share across all upstream paths, terminate on recurrent
+ * graphs, reach inputs across deep chains, and handle the trivial
+ * direct-input case correctly.
+ */
+
+import { approx, assert, assertEquals } from "./test_helpers.ts";
+
+import { computeTopContributingInputs } from "../docs/shared/graph_analysis.js";
+
+type Edge = {
+  fromUuid: string;
+  toUuid: string;
+  weight: number;
+  meanContribution: number;
+};
+
+function inboundLookup(
+  inbound: Record<string, Edge[]>,
+): (toUuid: string) => Edge[] {
+  return (toUuid: string) => inbound[toUuid] ?? [];
+}
+
+Deno.test("observation contributions: multiple paths to the same input sum correctly", () => {
+  // Two hidden neurons each reach the same input. Their attributions must
+  // accumulate rather than being treated as a single path.
+  const inbound: Record<string, Edge[]> = {
+    "output-0": [
+      {
+        fromUuid: "hidden-A",
+        toUuid: "output-0",
+        weight: 1,
+        meanContribution: 1,
+      },
+      {
+        fromUuid: "hidden-B",
+        toUuid: "output-0",
+        weight: 1,
+        meanContribution: 1,
+      },
+    ],
+    "hidden-A": [
+      {
+        fromUuid: "input-shared",
+        toUuid: "hidden-A",
+        weight: 1,
+        meanContribution: 1,
+      },
+    ],
+    "hidden-B": [
+      {
+        fromUuid: "input-shared",
+        toUuid: "hidden-B",
+        weight: 1,
+        meanContribution: 1,
+      },
+    ],
+  };
+
+  const res = computeTopContributingInputs({
+    focusUuid: "output-0",
+    getInboundEdges: inboundLookup(inbound),
+    exhaustive: true,
+  });
+
+  assert(!res.truncated, "walk should not truncate on a four-node graph");
+  assertEquals(res.inputs.length, 1, "only one distinct input exists");
+  const only = res.inputs[0];
+  assertEquals(only.uuid, "input-shared");
+  // Both paths contribute, normalised share must sum to 1.
+  approx(only.score, 1, 1e-9, "single input must receive the full share");
+});
+
+Deno.test("observation contributions: cycles are finite and deterministic", () => {
+  // hidden-A <-> hidden-B form a back-edge; without cycle handling the walk
+  // would otherwise loop on the recurrent connection.
+  const inbound: Record<string, Edge[]> = {
+    "output-0": [
+      {
+        fromUuid: "hidden-A",
+        toUuid: "output-0",
+        weight: 1,
+        meanContribution: 1,
+      },
+    ],
+    "hidden-A": [
+      {
+        fromUuid: "input-0",
+        toUuid: "hidden-A",
+        weight: 1,
+        meanContribution: 1,
+      },
+      {
+        fromUuid: "hidden-B",
+        toUuid: "hidden-A",
+        weight: 1,
+        meanContribution: 1,
+      },
+    ],
+    "hidden-B": [
+      {
+        fromUuid: "hidden-A",
+        toUuid: "hidden-B",
+        weight: 1,
+        meanContribution: 1,
+      },
+    ],
+  };
+
+  const start = performance.now();
+  const res = computeTopContributingInputs({
+    focusUuid: "output-0",
+    getInboundEdges: inboundLookup(inbound),
+    exhaustive: true,
+  });
+  const elapsedMs = performance.now() - start;
+
+  // Termination: well below any sane unit-test budget. A real infinite loop
+  // would never get here, but this guards against accidental slowdowns too.
+  assert(
+    elapsedMs < 2000,
+    `walk on a cycle should be fast; took ${elapsedMs.toFixed(1)}ms`,
+  );
+
+  // Only input-0 is reachable; hidden-B is a dead-end cycle that loops back
+  // through hidden-A (a node already on the path) so it contributes 0.
+  assertEquals(res.inputs.length, 1, "only input-0 should be reached");
+  assertEquals(res.inputs[0].uuid, "input-0");
+  approx(res.inputs[0].score, 1, 1e-9);
+
+  // Determinism: running the walk again returns identical output.
+  const second = computeTopContributingInputs({
+    focusUuid: "output-0",
+    getInboundEdges: inboundLookup(inbound),
+    exhaustive: true,
+  });
+  assertEquals(
+    JSON.stringify(second.inputs),
+    JSON.stringify(res.inputs),
+    "walk on a cycle must be deterministic across runs",
+  );
+});
+
+Deno.test("observation contributions: deep chains still reach the input", () => {
+  // Chain length 5: output -> h1 -> h2 -> h3 -> h4 -> input-deep
+  const inbound: Record<string, Edge[]> = {
+    "output-0": [{
+      fromUuid: "h1",
+      toUuid: "output-0",
+      weight: 1,
+      meanContribution: 1,
+    }],
+    "h1": [{
+      fromUuid: "h2",
+      toUuid: "h1",
+      weight: 1,
+      meanContribution: 1,
+    }],
+    "h2": [{
+      fromUuid: "h3",
+      toUuid: "h2",
+      weight: 1,
+      meanContribution: 1,
+    }],
+    "h3": [{
+      fromUuid: "h4",
+      toUuid: "h3",
+      weight: 1,
+      meanContribution: 1,
+    }],
+    "h4": [{
+      fromUuid: "input-deep",
+      toUuid: "h4",
+      weight: 1,
+      meanContribution: 1,
+    }],
+  };
+
+  const res = computeTopContributingInputs({
+    focusUuid: "output-0",
+    getInboundEdges: inboundLookup(inbound),
+    exhaustive: true,
+  });
+
+  assert(!res.truncated, "five-hop chain should not truncate");
+  assertEquals(res.inputs.length, 1);
+  assertEquals(res.inputs[0].uuid, "input-deep");
+  approx(res.inputs[0].score, 1, 1e-9);
+  // The recorded path includes every hop.
+  assertEquals(
+    res.inputs[0].path[res.inputs[0].path.length - 1],
+    "output-0",
+    "path must end at the focus output neuron",
+  );
+  assert(
+    res.inputs[0].path.includes("h1") &&
+      res.inputs[0].path.includes("h2") &&
+      res.inputs[0].path.includes("h3") &&
+      res.inputs[0].path.includes("h4"),
+    "path must contain every intermediate hidden neuron",
+  );
+});
+
+Deno.test("observation contributions: output with only direct input edges attributes 100% across them", () => {
+  const inbound: Record<string, Edge[]> = {
+    "output-0": [
+      {
+        fromUuid: "input-0",
+        toUuid: "output-0",
+        weight: 1,
+        meanContribution: 1,
+      },
+      {
+        fromUuid: "input-1",
+        toUuid: "output-0",
+        weight: 1,
+        meanContribution: 1,
+      },
+      {
+        fromUuid: "input-2",
+        toUuid: "output-0",
+        weight: 1,
+        meanContribution: 1,
+      },
+    ],
+  };
+
+  const res = computeTopContributingInputs({
+    focusUuid: "output-0",
+    getInboundEdges: inboundLookup(inbound),
+    exhaustive: true,
+  });
+
+  assert(!res.truncated);
+  assertEquals(res.inputs.length, 3);
+  const total = res.inputs.reduce((acc, r) => acc + r.score, 0);
+  approx(total, 1, 1e-9, "shares must sum to 1");
+  for (const r of res.inputs) {
+    approx(r.score, 1 / 3, 1e-9, `${r.uuid} should hold one third`);
+  }
+});
+
+Deno.test("observation contributions: exhaustive mode reaches wide fan-out that default bounds would truncate", () => {
+  // Build an output with 60 direct inputs. The default maxInboundPerNode is
+  // 40, so without exhaustive mode 20 inputs would silently be dropped.
+  const directEdges: Edge[] = [];
+  for (let i = 0; i < 60; i++) {
+    directEdges.push({
+      fromUuid: `input-${i}`,
+      toUuid: "output-0",
+      weight: 1,
+      meanContribution: 1,
+    });
+  }
+  const inbound: Record<string, Edge[]> = { "output-0": directEdges };
+
+  const defaultRes = computeTopContributingInputs({
+    focusUuid: "output-0",
+    getInboundEdges: inboundLookup(inbound),
+  });
+  assertEquals(
+    defaultRes.inputs.length,
+    40,
+    "default bounds cap the inbound fan-out at 40",
+  );
+
+  const exhaustiveRes = computeTopContributingInputs({
+    focusUuid: "output-0",
+    getInboundEdges: inboundLookup(inbound),
+    exhaustive: true,
+  });
+  assertEquals(
+    exhaustiveRes.inputs.length,
+    60,
+    "exhaustive mode must reach every direct input",
+  );
+  const total = exhaustiveRes.inputs.reduce((acc, r) => acc + r.score, 0);
+  approx(total, 1, 1e-9, "exhaustive shares must sum to 1");
+});
+
+Deno.test("observation contributions: default behaviour is unchanged for non-output callers", () => {
+  // Same toy graph as the original attribution_walk test, called without
+  // `exhaustive` — focus is a hidden neuron, so defaults must be unchanged.
+  const inbound: Record<string, Edge[]> = {
+    "hidden-A": [
+      {
+        fromUuid: "input-0",
+        toUuid: "hidden-A",
+        weight: 1,
+        meanContribution: 1,
+      },
+      {
+        fromUuid: "input-1",
+        toUuid: "hidden-A",
+        weight: 1,
+        meanContribution: 1,
+      },
+    ],
+  };
+
+  const res = computeTopContributingInputs({
+    focusUuid: "hidden-A",
+    getInboundEdges: inboundLookup(inbound),
+  });
+  assert(!res.truncated);
+  assertEquals(res.inputs.length, 2);
+  const total = res.inputs.reduce((acc, r) => acc + r.score, 0);
+  approx(total, 1, 1e-9);
+});


### PR DESCRIPTION
# Reinforce multi-hop observation attribution walk for output neurons

## Summary

Reinforces `computeTopContributingInputs` in `docs/shared/graph_analysis.js` so
it provably sums contribution share across all upstream paths when called from
an output neuron, and hardens the test suite to cover branching, cycle and depth
edge cases. Closes #185.

Concretely:

- Added an explicit **back-edge skip** during the upstream walk. Before
  enqueuing an inbound predecessor we check whether it already appears on the
  current walk's path; if so the edge is a back-edge and is skipped. This
  guarantees termination on recurrent graphs while still allowing the same
  neuron to be attributed along _different_ acyclic paths — which is exactly
  what "sum across all upstream paths" requires.
- Added a doc-comment block to `computeTopContributingInputs` describing the
  chosen cycle-handling mechanism.
- Added an `exhaustive` option that relaxes the per-node fan-out cap, the global
  work cap, the depth cap and the frontier-queue cap. It is intended for the
  small number of output-neuron callers (the consumer in issue #183) and leaves
  defaults unchanged for every other caller.

## Evidence

This is a backend / pure-module change with no UI surface. Verified via the test
suite (see Test Plan). Behaviour for non-output callers is explicitly pinned by
`observation contributions: default behaviour is
unchanged for non-output callers`.

```mermaid
flowchart LR
    F[focus = output neuron] --> A[hidden-A]
    F --> B[hidden-B]
    A --> X[input-shared]
    B --> X
    A -. back-edge .-> B
    B -. back-edge .-> A
```

Walks starting from `F` visit `input-shared` via both `A` and `B` and their
normalised shares sum to 1. The dashed back-edges are detected by the
path-membership check and never followed, so the walk terminates.

## Test Plan

Added `tests/observation_contributions_test.ts` covering:

- Multiple paths to the same input sum correctly.
- Cycles produce a finite, deterministic result (and complete well under a 2 s
  budget).
- Deep chains (depth 5) still reach the input.
- Output neurons with only direct input edges attribute 100% across those inputs
  (each input getting an equal third in the test case).
- `exhaustive: true` reaches a 60-wide fan-out that the default
  `maxInboundPerNode: 40` cap would otherwise truncate.
- Default behaviour for non-output callers is unchanged (regression guard
  against the new `exhaustive` defaults).

The existing `tests/attribution_walk_test.ts` continues to pass — verifying the
original two-hop attribution example is unaffected.

Quality gate:

- `./quality.sh < /dev/null` — 441 passed / 0 failed.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-185 -->