### PR TITLE
Add Observation contributions panel to output neuron card (#186)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -75,6 +75,9 @@ import { initThemeMode } from "./shared/theme.js";
 import { formatTraceScore } from "./shared/trace_score.js";
 import { escapeHtml, extractTooltips } from "./shared/ui_helpers.js";
 import {
+  buildObservationContributionsHtml,
+} from "./shared/observation_contributions.js";
+import {
   getInitialFocusTarget,
   installFocusTrap,
 } from "./shared/modal_focus.js";
@@ -241,18 +244,15 @@ const el = {
   pathModalBody: document.getElementById("pathModalBody"),
   pathModalClose: document.getElementById("pathModalClose"),
   pathModalMore: document.getElementById("pathModalMore"),
-  topInputsPanel: document.getElementById("topInputsPanel"),
+  observationContributionsPanel: document.getElementById(
+    "observationContributionsPanel",
+  ),
   obsBtn: document.getElementById("obsBtn"),
   obsModal: document.getElementById("obsModal"),
   obsModalBackdrop: document.getElementById("obsModalBackdrop"),
   obsModalTitle: document.getElementById("obsModalTitle"),
   obsModalBody: document.getElementById("obsModalBody"),
   obsModalClose: document.getElementById("obsModalClose"),
-  explainModal: document.getElementById("explainModal"),
-  explainModalBackdrop: document.getElementById("explainModalBackdrop"),
-  explainModalTitle: document.getElementById("explainModalTitle"),
-  explainModalBody: document.getElementById("explainModalBody"),
-  explainModalClose: document.getElementById("explainModalClose"),
   synapseCount: document.getElementById("synapseCount"),
   synapseSort: document.getElementById("synapseSort"),
   synapseMinAlloc: document.getElementById("synapseMinAlloc"),
@@ -1840,7 +1840,7 @@ function renderCurrentNeuron(uuid) {
 
   renderImpactBreakdown(uuid, impact);
   renderImpactDiagnosticsPanel(uuid, n.type);
-  renderTopInputsPanel(uuid, n.type);
+  renderObservationContributions(uuid, n.type);
   renderIssuesPanel(uuid, n.type);
   renderCandidatesPanel(uuid);
   applyNeuronTabState();
@@ -1875,16 +1875,24 @@ function computeTopContributingInputs(focusUuid, opts = {}) {
   });
 }
 
-function renderTopInputsPanel(uuid, neuronType) {
-  if (!el.topInputsPanel) return;
+/**
+ * Observation contributions panel (Issue #186).
+ *
+ * Renders the top 50 input observations ranked by their multi-hop share of
+ * the focused output neuron. Only rendered on output neuron cards; hidden
+ * and input neurons clear the panel and bail.
+ */
+function renderObservationContributions(uuid, neuronType) {
+  const panel = el.observationContributionsPanel;
+  if (!panel) return;
   if (!SNAPSHOT) {
-    el.topInputsPanel.innerHTML = "";
+    panel.innerHTML = "";
     return;
   }
 
-  // Inputs don't have meaningful upstream inputs.
-  if (uuid.startsWith("input-") || neuronType === "input") {
-    el.topInputsPanel.innerHTML = "";
+  // Restrict to output neurons (Issue #186).
+  if (neuronType !== "output") {
+    panel.innerHTML = "";
     return;
   }
 
@@ -1899,142 +1907,13 @@ function renderTopInputsPanel(uuid, neuronType) {
     TOP_INPUT_CACHE.set(cacheKey, cached);
   }
 
-  const top = (cached.inputs ?? []).slice(0, 8);
-  if (top.length === 0) {
-    el.topInputsPanel.innerHTML = "";
-    return;
-  }
-
-  const title = "Top observations → upstream";
-  const note =
-    "Bounded, explainable heuristic: walk upstream from the focused neuron using inbound share allocation, and summarise which inputs receive the most share. This is diagnostic, not ground truth.";
-
-  const headerHtml = `
-    <div class="impactBreakdownHeader">
-      <div class="impactBreakdownTitle">${escapeHtml(title)}</div>
-      <button class="impactBreakdownBtn" type="button" data-open-explain="1" title="Inspect full list">Inspect</button>
-    </div>
-    <div class="impactBreakdownNote">${escapeHtml(note)}</div>
-  `;
-
-  const rows = top.map((r) => {
-    const alias = getAlias(r.uuid);
-    const label = alias ? `${alias} (${r.uuid})` : r.uuid;
-    const pct = formatSig((r.score ?? 0) * 100, 4) + "%";
-    return `
-      <div class="impactBreakdownRow">
-        <div class="impactBreakdownOut">${escapeHtml(label)}</div>
-        <div class="impactBreakdownStats">
-          <span class="stat" title="Allocated share (normalised across shown inputs)">${
-      escapeHtml(pct)
-    }</span>
-        </div>
-      </div>
-    `;
-  }).join("");
-
-  el.topInputsPanel.innerHTML = headerHtml +
-    `<div class="impactBreakdownList">${rows}</div>`;
-
-  el.topInputsPanel.onclick = (ev) => {
-    const target = ev.target;
-    if (!(target instanceof HTMLElement)) return;
-    const btn = target.closest(".impactBreakdownBtn");
-    if (!btn) return;
-    if (btn.getAttribute("data-open-explain") === "1") openExplainModal(uuid);
-  };
-}
-
-function openExplainModal(focusUuid) {
-  if (!el.explainModal || !el.explainModalBody || !el.explainModalTitle) return;
-  _modalTrigger = document.activeElement;
-  el.explainModal.classList.add("isOpen");
-  el.explainModal.setAttribute("aria-hidden", "false");
-  renderExplainModal(focusUuid);
-  const panel = el.explainModal.querySelector(".modalPanel");
-  if (panel) {
-    const target = getInitialFocusTarget(panel);
-    if (target) target.focus();
-    _focusTrapCleanup = installFocusTrap(panel);
-  }
-}
-
-function closeExplainModal() {
-  if (!el.explainModal) return;
-  el.explainModal.classList.remove("isOpen");
-  el.explainModal.setAttribute("aria-hidden", "true");
-  if (_focusTrapCleanup) {
-    _focusTrapCleanup();
-    _focusTrapCleanup = null;
-  }
-  if (_modalTrigger && typeof _modalTrigger.focus === "function") {
-    _modalTrigger.focus();
-    _modalTrigger = null;
-  }
-}
-
-function renderExplainModal(focusUuid) {
-  if (!el.explainModalBody || !el.explainModalTitle) return;
-  if (!SNAPSHOT) return;
-
-  const cacheKey = `topInputs:${focusUuid}`;
-  const cached = TOP_INPUT_CACHE.get(cacheKey) ??
-    computeTopContributingInputs(focusUuid);
-
-  const focusLabel = truncateNeuronName(focusUuid);
-  el.explainModalTitle.textContent = `Top observations for ${focusLabel}`;
-
-  const truncatedNote = cached.truncated
-    ? `<div class="impactBreakdownTruncated" title="Computation was bounded to keep the UI fast on large creatures.">Truncated</div>`
-    : "";
-
-  const items = (cached.inputs ?? []).slice(0, 80).map((r) => {
-    const alias = getAlias(r.uuid);
-    const label = alias ? `${alias} (${r.uuid})` : r.uuid;
-    const pct = formatSig((r.score ?? 0) * 100, 6) + "%";
-    const path = Array.isArray(r.path)
-      ? r.path.map(truncateNeuronName).join(" → ")
-      : "";
-    return `
-      <div class="issueRow" data-jump-uuid="${escapeHtml(r.uuid)}">
-        <div class="issueRowTitle">${escapeHtml(label)}</div>
-        <div class="synapseStats">
-          <span class="stat" title="Allocated share (normalised across shown inputs)">${
-      escapeHtml(pct)
-    }</span>
-          <span class="stat" title="Example upstream chain (highest-share branch encountered)">${
-      escapeHtml(path)
-    }</span>
-        </div>
-      </div>
-    `;
-  }).join("");
-
-  el.explainModalBody.innerHTML = `
-    <div class="impactBreakdownHeader">
-      <div class="impactBreakdownTitle">Top contributing observations</div>
-      ${truncatedNote}
-    </div>
-    <div class="impactBreakdownNote">
-      We explore upstream using inbound share allocation (|meanContribution| fallback |weight|), bounded by depth and work limits so it stays fast on iPhone.
-      Tap a row to jump to that observation.
-    </div>
-    <div class="issueList">${
-    items || `<div class="emptyState">No inputs found.</div>`
-  }</div>
-  `;
-
-  el.explainModalBody.onclick = (ev) => {
-    const target = ev.target;
-    if (!(target instanceof HTMLElement)) return;
-    const row = target.closest("[data-jump-uuid]");
-    if (!row) return;
-    const uuid = row.getAttribute("data-jump-uuid");
-    if (uuid) {
-      closeExplainModal();
-      navigateTo(uuid);
-    }
-  };
+  panel.innerHTML = buildObservationContributionsHtml({
+    uuid,
+    neuronType,
+    inputs: cached.inputs ?? [],
+    getAlias,
+    getGroup: getInputGroup,
+  });
 }
 
 function renderImpactDiagnosticsPanel(uuid, neuronType) {
@@ -2330,17 +2209,6 @@ if (el.obsModalClose) {
 }
 document.addEventListener("keydown", (e) => {
   if (e.key === "Escape") closeObsModal();
-});
-
-// Explain modal wiring (close / backdrop / Esc).
-if (el.explainModalBackdrop) {
-  el.explainModalBackdrop.onclick = () => closeExplainModal();
-}
-if (el.explainModalClose) {
-  el.explainModalClose.onclick = () => closeExplainModal();
-}
-document.addEventListener("keydown", (e) => {
-  if (e.key === "Escape") closeExplainModal();
 });
 
 function getInboundSynapses(toUuid) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -225,7 +225,11 @@
           >
             <div id="impactBreakdown" class="impactBreakdown"></div>
             <div id="impactDiagnosticsPanel" class="impactBreakdown"></div>
-            <div id="topInputsPanel" class="impactBreakdown"></div>
+            <div
+              id="observationContributionsPanel"
+              class="impactBreakdown observationContributions"
+            >
+            </div>
           </div>
           <div
             id="neuronTabPanelIssues"
@@ -446,31 +450,6 @@
           </button>
         </div>
         <div id="obsModalBody" class="modalBody"></div>
-      </div>
-    </div>
-
-    <!-- Explain \"why this score\" modal (top contributing observations). -->
-    <div id="explainModal" class="modal" aria-hidden="true">
-      <div id="explainModalBackdrop" class="modalBackdrop"></div>
-      <div
-        class="modalPanel"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Top contributing observations"
-      >
-        <div class="modalHeader">
-          <div id="explainModalTitle" class="modalTitle">
-            Top contributing observations
-          </div>
-          <button
-            id="explainModalClose"
-            class="button buttonSmall buttonSecondary"
-            type="button"
-          >
-            Close
-          </button>
-        </div>
-        <div id="explainModalBody" class="modalBody"></div>
       </div>
     </div>
 

--- a/docs/pr-summary-186.md
+++ b/docs/pr-summary-186.md
@@ -1,0 +1,67 @@
+## Summary
+
+Replaces the previous "Top observations → upstream" preview-plus-modal pattern
+on neuron cards with a single "Observation contributions" panel that renders
+**only on output neuron cards** and lists up to 50 input observations ranked by
+their multi-hop share of the output. Each row shows the observation label and,
+when present, the `tooltips[].group` as a small subtitle. Closes #186.
+
+The render path is now backed by a new DOM-free module
+(`docs/shared/observation_contributions.js`) so the HTML-generation logic is
+unit-testable under Deno without a browser. The legacy "Inspect" button and the
+matching `openExplainModal` / `renderExplainModal` plumbing (and `#explainModal`
+markup) have been removed since they were only ever wired from this panel.
+
+## Evidence
+
+Backend / DOM-string change. No live browser environment is available in this
+worker run, so the rendering logic is verified directly against its HTML output:
+
+- `tests/observation_contributions_panel_test.ts` asserts the panel renders for
+  output neurons, is empty for hidden / input neurons, caps at 50 rows,
+  preserves the descending share order from the caller, includes the group
+  subtitle when a group is present, and HTML-escapes both label and group.
+- The full `./quality.sh` gate passes (format, lint, type check, **451 tests**).
+
+```mermaid
+flowchart LR
+  A[Output neuron card] --> B[renderObservationContributions]
+  B --> C[computeTopContributingInputs]
+  C --> D[buildObservationContributionsHtml]
+  D --> E[Row: label + group subtitle]
+  D -- non-output --> F[Empty panel]
+```
+
+## Test Plan
+
+- Added `tests/observation_contributions_panel_test.ts` (10 cases):
+  - `shouldRenderObservationContributions: only output neurons render`
+  - `buildObservationContributionsHtml: empty for hidden neurons`
+  - `buildObservationContributionsHtml: empty for input neurons`
+  - `buildObservationContributionsHtml: renders for output neurons`
+  - `buildObservationContributionsHtml: caps at 50 rows`
+  - `buildObservationContributionsHtml: preserves descending order from input`
+  - `buildObservationContributionsHtml: empty list produces empty string`
+  - `buildObservationContributionsHtml: renders group subtitle when present`
+  - `buildObservationContributionsRow: HTML-escapes label and group`
+  - `formatSharePercent: formats a fractional share as a percent string`
+- `tests/sw_static_files_test.ts` continues to pass after adding
+  `./shared/observation_contributions.js` to the SW precache list.
+- Full suite: `./quality.sh < /dev/null` → 451 passed.
+
+## Scope Notes
+
+- `docs/index.html`: renamed `#topInputsPanel` →
+  `#observationContributionsPanel` and removed the now-orphan `#explainModal`
+  markup.
+- `docs/app.js`: renamed `el.topInputsPanel` →
+  `el.observationContributionsPanel`, renamed `renderTopInputsPanel` →
+  `renderObservationContributions`, gated rendering to
+  `neuronType === "output"`, removed `openExplainModal` / `closeExplainModal` /
+  `renderExplainModal` and their event wiring (only used by this panel).
+- `docs/styles.css`: added `.observationContributionsGroup` (small muted
+  subtitle) and a thin label wrapper to stack name and group.
+- `docs/sw.js`: precaches the new shared module so deploys cannot serve a stale
+  `app.js` against a missing helper.
+- `README.md`: no change — the previous "Top observations → upstream" wording is
+  not documented there.

--- a/docs/shared/observation_contributions.js
+++ b/docs/shared/observation_contributions.js
@@ -1,0 +1,154 @@
+/**
+ * Observation contributions panel (Issue #186).
+ *
+ * Pure, DOM-free helpers for the "Observation contributions" panel shown on
+ * the output neuron card in the Trace Explorer. The panel ranks the top
+ * input observations by their multi-hop share of the output and shows each
+ * observation's tooltip group as a small subtitle.
+ *
+ * This module is intentionally DOM-free so it can be unit-tested under
+ * Deno. The browser bootstrap (docs/app.js) is responsible for plugging it
+ * into the DOM and for sourcing the inputs from
+ * `computeTopContributingInputs`.
+ */
+
+import { escapeHtml } from "./ui_helpers.js";
+
+/** Maximum number of rows the panel renders inline. */
+export const MAX_OBSERVATION_ROWS = 50;
+
+/**
+ * @typedef {object} ObservationContribution
+ * @property {string} uuid — observation neuron UUID (typically `input-N`).
+ * @property {number} score — normalised share in [0, 1].
+ */
+
+/**
+ * Decide whether the panel should render for the given neuron.
+ *
+ * Per issue #186 the panel lives only on output neuron cards. Hidden and
+ * input neurons never host the panel.
+ *
+ * @param {string} uuid
+ * @param {string|null|undefined} neuronType
+ * @returns {boolean}
+ */
+export function shouldRenderObservationContributions(uuid, neuronType) {
+  if (typeof uuid !== "string" || uuid.length === 0) return false;
+  if (neuronType !== "output") return false;
+  // Defensive: callers occasionally pass output-only UUIDs without a type.
+  // We still gate strictly on neuronType being "output".
+  return true;
+}
+
+/**
+ * Format a fractional share as a percent string with the given precision.
+ *
+ * Kept here (rather than importing the app.js `formatSig`) so the module
+ * stays self-contained.
+ *
+ * @param {number} share — value in [0, 1].
+ * @param {number} [sigFigs=4]
+ * @returns {string}
+ */
+export function formatSharePercent(share, sigFigs = 4) {
+  const n = Number(share) || 0;
+  const pct = n * 100;
+  if (!Number.isFinite(pct)) return "0%";
+  // Use toPrecision then strip trailing zeros for a compact display.
+  const s = pct.toPrecision(Math.max(1, sigFigs));
+  // toPrecision can return exponential notation for very small/large values;
+  // for the inline panel that's still acceptable.
+  return `${s}%`;
+}
+
+/**
+ * Build the HTML for a single observation row.
+ *
+ * Exposed for testing. Use {@link buildObservationContributionsHtml} for
+ * the full panel.
+ *
+ * @param {ObservationContribution} row
+ * @param {{ getAlias?: (uuid: string) => (string | null), getGroup?: (uuid: string) => (string | null) }} [lookups]
+ * @returns {string}
+ */
+export function buildObservationContributionsRow(row, lookups = {}) {
+  const { getAlias, getGroup } = lookups;
+  const uuid = String(row?.uuid ?? "");
+  const alias = typeof getAlias === "function" ? getAlias(uuid) : null;
+  const group = typeof getGroup === "function" ? getGroup(uuid) : null;
+  const label = alias ? `${alias} (${uuid})` : uuid;
+  const pct = formatSharePercent(row?.score);
+
+  const subtitle = group
+    ? `<div class="observationContributionsGroup">${escapeHtml(group)}</div>`
+    : "";
+
+  return `
+      <div class="impactBreakdownRow observationContributionsRow" data-uuid="${
+    escapeHtml(uuid)
+  }">
+        <div class="observationContributionsLabelWrap">
+          <div class="impactBreakdownOut">${escapeHtml(label)}</div>
+          ${subtitle}
+        </div>
+        <div class="impactBreakdownStats">
+          <span class="stat" title="Allocated share (normalised across shown inputs)">${
+    escapeHtml(pct)
+  }</span>
+        </div>
+      </div>
+    `;
+}
+
+/**
+ * Build the full HTML for the Observation contributions panel.
+ *
+ * Returns an empty string when the panel should not render (non-output
+ * neuron, or no contributions). Callers (typically docs/app.js) set the
+ * returned string as the panel container's innerHTML.
+ *
+ * @param {object} params
+ * @param {string} params.uuid — focused output neuron UUID.
+ * @param {string|null|undefined} params.neuronType — focused neuron's `n.type`.
+ * @param {ObservationContribution[]} params.inputs — already-sorted descending by share.
+ * @param {(uuid: string) => (string | null)} [params.getAlias]
+ * @param {(uuid: string) => (string | null)} [params.getGroup]
+ * @param {number} [params.max=MAX_OBSERVATION_ROWS]
+ * @returns {string}
+ */
+export function buildObservationContributionsHtml(params) {
+  const {
+    uuid,
+    neuronType,
+    inputs,
+    getAlias,
+    getGroup,
+    max = MAX_OBSERVATION_ROWS,
+  } = params ?? {};
+
+  if (!shouldRenderObservationContributions(uuid, neuronType)) return "";
+
+  const safeInputs = Array.isArray(inputs) ? inputs : [];
+  const top = safeInputs.slice(0, max);
+  if (top.length === 0) return "";
+
+  const title = "Observation contributions";
+  const note =
+    "Top input observations ranked by their multi-hop share of this output. " +
+    "Each row shows the observation's group as a subtitle when available.";
+
+  const headerHtml = `
+    <div class="impactBreakdownHeader">
+      <div class="impactBreakdownTitle">${escapeHtml(title)}</div>
+    </div>
+    <div class="impactBreakdownNote">${escapeHtml(note)}</div>
+  `;
+
+  const rows = top
+    .map((row) => buildObservationContributionsRow(row, { getAlias, getGroup }))
+    .join("");
+
+  return headerHtml +
+    `<div class="impactBreakdownList observationContributionsList">${rows}</div>`;
+}

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -798,6 +798,23 @@ body {
   max-width: 140px;
 }
 
+/* Observation contributions panel (Issue #186). */
+.observationContributionsLabelWrap {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 2px;
+}
+
+.observationContributionsGroup {
+  font-size: 11px;
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 140px;
+}
+
 .impactBreakdownStats {
   display: flex;
   flex-wrap: wrap;

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -56,6 +56,7 @@ const STATIC_FILES = [
   "./shared/ui_helpers.js",
   "./shared/modal_focus.js",
   "./shared/trace_header.js",
+  "./shared/observation_contributions.js",
   "./icons/icon-72x72.png",
   "./icons/icon-16x16.png",
   "./icons/icon-32x32.png",

--- a/tests/observation_contributions_panel_test.ts
+++ b/tests/observation_contributions_panel_test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for docs/shared/observation_contributions.js (Issue #186).
+ *
+ * The "Observation contributions" panel renders inline on the output neuron
+ * card in the Trace Explorer. It must:
+ *   - render only for output neurons (hidden / input neurons render nothing);
+ *   - show up to 50 rows in descending share order;
+ *   - render each row with the observation label and the optional
+ *     `tooltips[].group` subtitle.
+ *
+ * Browser-only behaviour (real DOM, click handlers) cannot be exercised in
+ * Deno; the rendering logic is intentionally HTML-string based so it can be
+ * tested directly here.
+ */
+
+import { assert, assertEquals } from "./test_helpers.ts";
+
+import {
+  buildObservationContributionsHtml,
+  buildObservationContributionsRow,
+  formatSharePercent,
+  MAX_OBSERVATION_ROWS,
+  shouldRenderObservationContributions,
+} from "../docs/shared/observation_contributions.js";
+
+type Row = { uuid: string; score: number };
+
+function makeRows(n: number): Row[] {
+  const rows: Row[] = [];
+  for (let i = 0; i < n; i++) {
+    rows.push({ uuid: `input-${i}`, score: (n - i) / n });
+  }
+  return rows;
+}
+
+function countRows(html: string): number {
+  const matches = html.match(/observationContributionsRow/g);
+  return matches ? matches.length : 0;
+}
+
+Deno.test("shouldRenderObservationContributions: only output neurons render", () => {
+  assert(shouldRenderObservationContributions("output-0", "output"));
+  assert(!shouldRenderObservationContributions("input-3", "input"));
+  assert(!shouldRenderObservationContributions("hidden-9", "hidden"));
+  assert(!shouldRenderObservationContributions("output-0", undefined));
+  assert(!shouldRenderObservationContributions("", "output"));
+});
+
+Deno.test("buildObservationContributionsHtml: empty for hidden neurons", () => {
+  const html = buildObservationContributionsHtml({
+    uuid: "hidden-1",
+    neuronType: "hidden",
+    inputs: makeRows(5),
+  });
+  assertEquals(html, "");
+});
+
+Deno.test("buildObservationContributionsHtml: empty for input neurons", () => {
+  const html = buildObservationContributionsHtml({
+    uuid: "input-2",
+    neuronType: "input",
+    inputs: makeRows(5),
+  });
+  assertEquals(html, "");
+});
+
+Deno.test("buildObservationContributionsHtml: renders for output neurons", () => {
+  const html = buildObservationContributionsHtml({
+    uuid: "output-0",
+    neuronType: "output",
+    inputs: makeRows(3),
+  });
+  assert(html.length > 0, "output neuron should render non-empty HTML");
+  assert(
+    html.includes("Observation contributions"),
+    "heading must read 'Observation contributions'",
+  );
+  assertEquals(countRows(html), 3);
+});
+
+Deno.test("buildObservationContributionsHtml: caps at 50 rows", () => {
+  const html = buildObservationContributionsHtml({
+    uuid: "output-0",
+    neuronType: "output",
+    inputs: makeRows(120),
+  });
+  assertEquals(countRows(html), MAX_OBSERVATION_ROWS);
+  assertEquals(countRows(html), 50);
+});
+
+Deno.test("buildObservationContributionsHtml: preserves descending order from input", () => {
+  // Caller is responsible for sorting; we verify ordering is preserved.
+  const rows: Row[] = [
+    { uuid: "input-a", score: 0.5 },
+    { uuid: "input-b", score: 0.3 },
+    { uuid: "input-c", score: 0.2 },
+  ];
+  const html = buildObservationContributionsHtml({
+    uuid: "output-0",
+    neuronType: "output",
+    inputs: rows,
+  });
+
+  const idxA = html.indexOf("input-a");
+  const idxB = html.indexOf("input-b");
+  const idxC = html.indexOf("input-c");
+  assert(idxA > -1 && idxB > -1 && idxC > -1, "all rows must render");
+  assert(idxA < idxB, "highest share renders first");
+  assert(idxB < idxC, "ordering preserved across the list");
+});
+
+Deno.test("buildObservationContributionsHtml: empty list produces empty string", () => {
+  const html = buildObservationContributionsHtml({
+    uuid: "output-0",
+    neuronType: "output",
+    inputs: [],
+  });
+  assertEquals(html, "");
+});
+
+Deno.test("buildObservationContributionsHtml: renders group subtitle when present", () => {
+  const rows: Row[] = [
+    { uuid: "input-temp", score: 0.6 },
+    { uuid: "input-pressure", score: 0.4 },
+  ];
+  const labels: Record<string, string> = {
+    "input-temp": "Temperature",
+    "input-pressure": "Pressure",
+  };
+  const groups: Record<string, string> = {
+    "input-temp": "Sensors",
+    // input-pressure has no group on purpose.
+  };
+
+  const html = buildObservationContributionsHtml({
+    uuid: "output-0",
+    neuronType: "output",
+    inputs: rows,
+    getAlias: (uuid) => labels[uuid] ?? null,
+    getGroup: (uuid) => groups[uuid] ?? null,
+  });
+
+  assert(
+    html.includes("Temperature (input-temp)"),
+    "row must include the alias and UUID",
+  );
+  assert(
+    html.includes(
+      `<div class="observationContributionsGroup">Sensors</div>`,
+    ),
+    "group subtitle must render when the group is present",
+  );
+  // The pressure row has no group: no subtitle div should reference 'pressure'.
+  const pressureSegment = html.slice(
+    html.indexOf("input-pressure"),
+    html.indexOf("input-pressure") + 400,
+  );
+  assert(
+    !pressureSegment.includes("observationContributionsGroup"),
+    "no subtitle rendered when group is absent",
+  );
+});
+
+Deno.test("buildObservationContributionsRow: HTML-escapes label and group", () => {
+  const html = buildObservationContributionsRow(
+    { uuid: "input-x", score: 0.25 },
+    {
+      getAlias: () => "<script>alert(1)</script>",
+      getGroup: () => "Group & Co",
+    },
+  );
+  assert(
+    html.includes("&lt;script&gt;alert(1)&lt;/script&gt;"),
+    "label must be HTML-escaped",
+  );
+  assert(html.includes("Group &amp; Co"), "group must be HTML-escaped");
+});
+
+Deno.test("formatSharePercent: formats a fractional share as a percent string", () => {
+  assertEquals(formatSharePercent(0.5, 4), "50.00%");
+  assertEquals(formatSharePercent(1, 4), "100.0%");
+  assertEquals(formatSharePercent(0, 4), "0.000%");
+});


### PR DESCRIPTION
## Summary

Replaces the previous "Top observations → upstream" preview-plus-modal pattern
on neuron cards with a single "Observation contributions" panel that renders
**only on output neuron cards** and lists up to 50 input observations ranked by
their multi-hop share of the output. Each row shows the observation label and,
when present, the `tooltips[].group` as a small subtitle. Closes #186.

The render path is now backed by a new DOM-free module
(`docs/shared/observation_contributions.js`) so the HTML-generation logic is
unit-testable under Deno without a browser. The legacy "Inspect" button and the
matching `openExplainModal` / `renderExplainModal` plumbing (and `#explainModal`
markup) have been removed since they were only ever wired from this panel.

## Evidence

Backend / DOM-string change. No live browser environment is available in this
worker run, so the rendering logic is verified directly against its HTML output:

- `tests/observation_contributions_panel_test.ts` asserts the panel renders for
  output neurons, is empty for hidden / input neurons, caps at 50 rows,
  preserves the descending share order from the caller, includes the group
  subtitle when a group is present, and HTML-escapes both label and group.
- The full `./quality.sh` gate passes (format, lint, type check, **451 tests**).

```mermaid
flowchart LR
  A[Output neuron card] --> B[renderObservationContributions]
  B --> C[computeTopContributingInputs]
  C --> D[buildObservationContributionsHtml]
  D --> E[Row: label + group subtitle]
  D -- non-output --> F[Empty panel]
```

## Test Plan

- Added `tests/observation_contributions_panel_test.ts` (10 cases):
  - `shouldRenderObservationContributions: only output neurons render`
  - `buildObservationContributionsHtml: empty for hidden neurons`
  - `buildObservationContributionsHtml: empty for input neurons`
  - `buildObservationContributionsHtml: renders for output neurons`
  - `buildObservationContributionsHtml: caps at 50 rows`
  - `buildObservationContributionsHtml: preserves descending order from input`
  - `buildObservationContributionsHtml: empty list produces empty string`
  - `buildObservationContributionsHtml: renders group subtitle when present`
  - `buildObservationContributionsRow: HTML-escapes label and group`
  - `formatSharePercent: formats a fractional share as a percent string`
- `tests/sw_static_files_test.ts` continues to pass after adding
  `./shared/observation_contributions.js` to the SW precache list.
- Full suite: `./quality.sh < /dev/null` → 451 passed.

## Scope Notes

- `docs/index.html`: renamed `#topInputsPanel` →
  `#observationContributionsPanel` and removed the now-orphan `#explainModal`
  markup.
- `docs/app.js`: renamed `el.topInputsPanel` →
  `el.observationContributionsPanel`, renamed `renderTopInputsPanel` →
  `renderObservationContributions`, gated rendering to
  `neuronType === "output"`, removed `openExplainModal` / `closeExplainModal` /
  `renderExplainModal` and their event wiring (only used by this panel).
- `docs/styles.css`: added `.observationContributionsGroup` (small muted
  subtitle) and a thin label wrapper to stack name and group.
- `docs/sw.js`: precaches the new shared module so deploys cannot serve a stale
  `app.js` against a missing helper.
- `README.md`: no change — the previous "Top observations → upstream" wording is
  not documented there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)