### PR TITLE
fix(pwa): self-heal on app-shell load failure (#194)

### DIFF
--- a/docs/graph/index.html
+++ b/docs/graph/index.html
@@ -222,12 +222,36 @@
           await import(`./graph.js?v=${v}`);
         } catch (err) {
           // Issue #126: Show a visible error when module import fails.
+          //
+          // Issue #194: PWA self-heal — see docs/index.html for the rationale.
           console.error("Graph module failed to load:", err);
           const statusEl = document.getElementById("status");
           if (statusEl) {
-            statusEl.textContent =
-              "Failed to load app — please clear your browser cache and reload.";
-            statusEl.className = "statusInline bad";
+            statusEl.textContent = "Recovering — refreshing PWA caches…";
+            statusEl.className = "statusInline";
+          }
+          try {
+            const { recoverFromFailedAppLoad } = await import(
+              `../shared/pwa_recovery.js?v=${v}`
+            );
+            const result = await recoverFromFailedAppLoad({
+              storage: globalThis.sessionStorage,
+              cachesApi: globalThis.caches,
+              swContainer: navigator.serviceWorker,
+              reload: () => globalThis.location.reload(),
+            });
+            if (!result.recovered && statusEl) {
+              statusEl.textContent =
+                "Failed to load app. Tap and hold the icon, remove the app, then reinstall.";
+              statusEl.className = "statusInline bad";
+            }
+          } catch (recoveryErr) {
+            console.error("PWA recovery failed:", recoveryErr);
+            if (statusEl) {
+              statusEl.textContent =
+                "Failed to load app. Tap and hold the icon, remove the app, then reinstall.";
+              statusEl.className = "statusInline bad";
+            }
           }
         }
       })();

--- a/docs/index.html
+++ b/docs/index.html
@@ -389,12 +389,40 @@
           // Issue #126: If the module fails to import (e.g., stale cached
           // dependency missing an expected export), show a visible error
           // instead of failing silently with no UI indication.
+          //
+          // Issue #194: For a PWA — especially on iOS — telling the user to
+          // "clear your browser cache" is a dead end (there is no obvious
+          // cache to clear). Attempt automatic recovery instead: clear all
+          // caches, unregister the SW, and reload. A session flag inside the
+          // helper prevents an infinite recovery loop.
           console.error("App module failed to load:", err);
           const statusEl = document.getElementById("status");
           if (statusEl) {
-            statusEl.textContent =
-              "Failed to load app — please clear your browser cache and reload.";
-            statusEl.className = "statusInline bad";
+            statusEl.textContent = "Recovering — refreshing PWA caches…";
+            statusEl.className = "statusInline";
+          }
+          try {
+            const { recoverFromFailedAppLoad } = await import(
+              `./shared/pwa_recovery.js?v=${v}`
+            );
+            const result = await recoverFromFailedAppLoad({
+              storage: globalThis.sessionStorage,
+              cachesApi: globalThis.caches,
+              swContainer: navigator.serviceWorker,
+              reload: () => globalThis.location.reload(),
+            });
+            if (!result.recovered && statusEl) {
+              statusEl.textContent =
+                "Failed to load app. Tap and hold the icon, remove the app, then reinstall.";
+              statusEl.className = "statusInline bad";
+            }
+          } catch (recoveryErr) {
+            console.error("PWA recovery failed:", recoveryErr);
+            if (statusEl) {
+              statusEl.textContent =
+                "Failed to load app. Tap and hold the icon, remove the app, then reinstall.";
+              statusEl.className = "statusInline bad";
+            }
           }
         }
       })();

--- a/docs/pr-summary-194.md
+++ b/docs/pr-summary-194.md
@@ -1,0 +1,80 @@
+# Issue #194 — PWA self-heal on app-shell load failure
+
+## Summary
+
+The previous error path showed **"Failed to load app — please clear your browser
+cache and reload"** when a cached `app.js`/`graph.js` import failed. On an
+installed PWA — especially on iOS — that is a dead end: there is no obvious
+cache to clear without uninstalling the app, and the last cached model never
+gets a chance to render.
+
+This change replaces the dead-end message with an automatic self-heal: clear
+every Cache Storage cache, unregister every Service Worker, and reload. A
+`sessionStorage` flag guards against an infinite recovery loop if the failure is
+not actually cache-related. Closes #194.
+
+```mermaid
+flowchart TD
+    boot["Bootstrap script in index.html"] --> reg["Register Service Worker"]
+    reg --> imp{"import app.js<br/>succeeds?"}
+    imp -->|"yes"| app["App renders snapshot"]
+    imp -->|"no — stale cache"| status["Status: Recovering — refreshing PWA caches…"]
+    status --> rec["recoverFromFailedAppLoad()"]
+    rec --> flag{"sessionStorage flag<br/>already set?"}
+    flag -->|"no"| clear["Clear all caches +<br/>unregister SWs +<br/>reload"]
+    flag -->|"yes"| reinstall["Status: remove the app and reinstall"]
+    clear --> boot
+```
+
+## Files changed
+
+- **New**: `docs/shared/pwa_recovery.js` — dependency-injected recovery helper
+  (testable in Deno).
+- **New**: `tests/pwa_recovery_test.ts` — 13 unit tests covering the happy path,
+  loop-guard, and graceful handling of missing
+  `sessionStorage`/`caches`/`navigator.serviceWorker`.
+- **Modified**: `docs/index.html`, `docs/graph/index.html`,
+  `docs/starfield/index.html` — replaced the dead-end error message with a call
+  to `recoverFromFailedAppLoad`.
+- **Modified**: `docs/sw.js` — added `./shared/pwa_recovery.js` to
+  `STATIC_FILES` so the helper is reachable offline.
+- **Modified**: `tests/sw_static_files_test.ts` — added regression tests to
+  ensure the old "please clear your browser cache" string never reappears in an
+  HTML entry point, and that the helper stays in `STATIC_FILES`.
+
+## Evidence
+
+This is a backend/UX change to a bootstrap error path that only fires on a
+broken cached deploy. The recovery flow is exercised end-to-end by the unit
+tests in `tests/pwa_recovery_test.ts`.
+
+```text
+running 13 tests from ./tests/pwa_recovery_test.ts
+shouldAttemptRecovery returns true when no flag set ... ok
+shouldAttemptRecovery returns false after markRecoveryAttempted ... ok
+clearRecoveryFlag removes the flag ... ok
+shouldAttemptRecovery handles null storage gracefully ... ok
+shouldAttemptRecovery handles throwing storage gracefully ... ok
+markRecoveryAttempted handles throwing storage gracefully ... ok
+clearAllCaches deletes every cache key ... ok
+clearAllCaches with no caches API returns empty list ... ok
+unregisterAllServiceWorkers unregisters every registration ... ok
+unregisterAllServiceWorkers handles missing container ... ok
+recoverFromFailedAppLoad clears caches, unregisters SW, reloads ... ok
+recoverFromFailedAppLoad refuses second attempt ... ok
+recoverFromFailedAppLoad with no storage still refuses (cannot guard against loop) ... ok
+ok | 13 passed | 0 failed
+```
+
+Full `./quality.sh` run: **466 passed, 0 failed.**
+
+## Test plan
+
+- [x] `deno test -A tests/pwa_recovery_test.ts` — new unit tests pass.
+- [x] `./quality.sh` — full quality gate passes (fmt + lint + 466 tests).
+- [x] Regression test in `tests/sw_static_files_test.ts` confirms the misleading
+      "please clear your browser cache" wording no longer appears in any HTML
+      entry point.
+- [x] Regression test confirms `pwa_recovery.js` is precached by the SW so the
+      recovery helper is itself reachable when the original failure was caused
+      by a stale cache.

--- a/docs/shared/pwa_recovery.js
+++ b/docs/shared/pwa_recovery.js
@@ -1,0 +1,120 @@
+/**
+ * PWA recovery helper (Issue #194).
+ *
+ * When the app shell loads from the Service Worker cache but the cached
+ * `app.js` (or one of its dependencies) is stale and fails to import, we
+ * used to tell the user to "clear your browser cache and reload". On an
+ * installed PWA — especially on iOS — that is a dead end: there is no
+ * obvious cache to clear without uninstalling the app.
+ *
+ * This module replaces that dead-end with an automatic self-heal:
+ *
+ *   1. Set a `sessionStorage` flag so we only attempt once per session.
+ *   2. Delete every Cache Storage cache (static + runtime + snapshots).
+ *   3. Unregister every Service Worker.
+ *   4. Reload the page — the next load will fetch fresh assets and
+ *      register a fresh Service Worker.
+ *
+ * The session flag prevents an infinite recovery loop if the underlying
+ * failure is not actually caching-related (e.g. a genuine network outage
+ * or a syntax error in the deployed JS).
+ *
+ * All side-effect surfaces (storage, caches, navigator.serviceWorker,
+ * location.reload) are injected so the logic is testable under Deno.
+ */
+
+const RECOVERY_FLAG_KEY = "neatAiExplore_pwaRecoveryAttempt";
+
+/**
+ * @param {Storage | null | undefined} storage
+ * @returns {boolean} true if a recovery attempt has not yet been made this session.
+ */
+export function shouldAttemptRecovery(storage) {
+  if (!storage) return false;
+  try {
+    return storage.getItem(RECOVERY_FLAG_KEY) !== "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {Storage | null | undefined} storage
+ */
+export function markRecoveryAttempted(storage) {
+  if (!storage) return;
+  try {
+    storage.setItem(RECOVERY_FLAG_KEY, "1");
+  } catch {
+    // sessionStorage may be unavailable (private browsing, quota, etc.).
+  }
+}
+
+/**
+ * @param {Storage | null | undefined} storage
+ */
+export function clearRecoveryFlag(storage) {
+  if (!storage) return;
+  try {
+    storage.removeItem(RECOVERY_FLAG_KEY);
+  } catch {
+    // Ignore.
+  }
+}
+
+/**
+ * Delete every Cache Storage cache.
+ *
+ * @param {CacheStorage | null | undefined} cachesApi
+ * @returns {Promise<string[]>} the cache keys that were deleted.
+ */
+export async function clearAllCaches(cachesApi) {
+  if (!cachesApi || typeof cachesApi.keys !== "function") return [];
+  const keys = await cachesApi.keys();
+  await Promise.all(keys.map((k) => cachesApi.delete(k)));
+  return keys;
+}
+
+/**
+ * Unregister every Service Worker registration.
+ *
+ * @param {ServiceWorkerContainer | null | undefined} swContainer
+ * @returns {Promise<number>} the number of registrations unregistered.
+ */
+export async function unregisterAllServiceWorkers(swContainer) {
+  if (!swContainer || typeof swContainer.getRegistrations !== "function") {
+    return 0;
+  }
+  const regs = await swContainer.getRegistrations();
+  await Promise.all(regs.map((r) => r.unregister()));
+  return regs.length;
+}
+
+/**
+ * Attempt to recover from a failed app-shell load.
+ *
+ * @param {object} deps
+ * @param {Storage | null} deps.storage - sessionStorage (or compatible).
+ * @param {CacheStorage | null} deps.cachesApi - window.caches (or compatible).
+ * @param {ServiceWorkerContainer | null} deps.swContainer -
+ *   navigator.serviceWorker (or compatible).
+ * @param {() => void} deps.reload - called to trigger a page reload.
+ * @returns {Promise<{recovered: boolean, reason: string}>}
+ */
+export async function recoverFromFailedAppLoad(deps) {
+  const { storage, cachesApi, swContainer, reload } = deps ?? {};
+
+  // Without storage we cannot detect repeated attempts, so refuse outright —
+  // an infinite reload spiral is worse than a stuck error message.
+  if (!storage) {
+    return { recovered: false, reason: "no-storage" };
+  }
+  if (!shouldAttemptRecovery(storage)) {
+    return { recovered: false, reason: "already-attempted" };
+  }
+  markRecoveryAttempted(storage);
+  await clearAllCaches(cachesApi);
+  await unregisterAllServiceWorkers(swContainer);
+  if (typeof reload === "function") reload();
+  return { recovered: true, reason: "cleared-and-reloaded" };
+}

--- a/docs/starfield/index.html
+++ b/docs/starfield/index.html
@@ -234,7 +234,40 @@
         const v = buildId.includes("__BUILD_ID__")
           ? String(Date.now())
           : buildId;
-        await import(`./starfield.js?v=${v}`);
+        try {
+          await import(`./starfield.js?v=${v}`);
+        } catch (err) {
+          // Issue #194: PWA self-heal — clear caches, unregister SW, reload.
+          console.error("Starfield module failed to load:", err);
+          const statusEl = document.getElementById("status");
+          if (statusEl) {
+            statusEl.textContent = "Recovering — refreshing PWA caches…";
+            statusEl.className = "statusInline";
+          }
+          try {
+            const { recoverFromFailedAppLoad } = await import(
+              `../shared/pwa_recovery.js?v=${v}`
+            );
+            const result = await recoverFromFailedAppLoad({
+              storage: globalThis.sessionStorage,
+              cachesApi: globalThis.caches,
+              swContainer: navigator.serviceWorker,
+              reload: () => globalThis.location.reload(),
+            });
+            if (!result.recovered && statusEl) {
+              statusEl.textContent =
+                "Failed to load app. Tap and hold the icon, remove the app, then reinstall.";
+              statusEl.className = "statusInline bad";
+            }
+          } catch (recoveryErr) {
+            console.error("PWA recovery failed:", recoveryErr);
+            if (statusEl) {
+              statusEl.textContent =
+                "Failed to load app. Tap and hold the icon, remove the app, then reinstall.";
+              statusEl.className = "statusInline bad";
+            }
+          }
+        }
       })();
     </script>
   </body>

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -57,6 +57,7 @@ const STATIC_FILES = [
   "./shared/modal_focus.js",
   "./shared/trace_header.js",
   "./shared/observation_contributions.js",
+  "./shared/pwa_recovery.js",
   "./icons/icon-72x72.png",
   "./icons/icon-16x16.png",
   "./icons/icon-32x32.png",

--- a/tests/pwa_recovery_test.ts
+++ b/tests/pwa_recovery_test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for docs/shared/pwa_recovery.js (Issue #194).
+ *
+ * The PWA recovery helper turns the previous "please clear your browser
+ * cache and reload" dead-end (which iOS PWA users cannot action) into an
+ * automatic self-heal: clear caches, unregister service workers, then
+ * reload. A session-storage flag prevents an infinite recovery loop.
+ */
+
+import { assert, assertEquals } from "./test_helpers.ts";
+import {
+  clearAllCaches,
+  clearRecoveryFlag,
+  markRecoveryAttempted,
+  recoverFromFailedAppLoad,
+  shouldAttemptRecovery,
+  unregisterAllServiceWorkers,
+} from "../docs/shared/pwa_recovery.js";
+
+function fakeStorage(): Storage & { _data: Map<string, string> } {
+  const data = new Map<string, string>();
+  return {
+    _data: data,
+    getItem: (k: string) => (data.has(k) ? data.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      data.set(k, v);
+    },
+    removeItem: (k: string) => {
+      data.delete(k);
+    },
+    clear: () => data.clear(),
+    key: (i: number) => Array.from(data.keys())[i] ?? null,
+    get length() {
+      return data.size;
+    },
+  } as Storage & { _data: Map<string, string> };
+}
+
+interface FakeCache {
+  keys(): Promise<string[]>;
+  delete(key: string): Promise<boolean>;
+  deletedKeys: string[];
+}
+
+function fakeCaches(initialKeys: string[]): FakeCache {
+  const keys = [...initialKeys];
+  const deletedKeys: string[] = [];
+  return {
+    keys: () => Promise.resolve([...keys]),
+    delete: (key: string) => {
+      deletedKeys.push(key);
+      const idx = keys.indexOf(key);
+      if (idx >= 0) keys.splice(idx, 1);
+      return Promise.resolve(true);
+    },
+    deletedKeys,
+  };
+}
+
+interface FakeRegistration {
+  unregister(): Promise<boolean>;
+  unregistered: boolean;
+}
+
+function fakeRegistration(): FakeRegistration {
+  const reg: FakeRegistration = {
+    unregistered: false,
+    unregister: () => {
+      reg.unregistered = true;
+      return Promise.resolve(true);
+    },
+  };
+  return reg;
+}
+
+interface FakeSwContainer {
+  getRegistrations(): Promise<FakeRegistration[]>;
+}
+
+function fakeSwContainer(regs: FakeRegistration[]): FakeSwContainer {
+  return {
+    getRegistrations: () => Promise.resolve(regs),
+  };
+}
+
+Deno.test("shouldAttemptRecovery returns true when no flag set", () => {
+  const storage = fakeStorage();
+  assertEquals(shouldAttemptRecovery(storage), true);
+});
+
+Deno.test("shouldAttemptRecovery returns false after markRecoveryAttempted", () => {
+  const storage = fakeStorage();
+  markRecoveryAttempted(storage);
+  assertEquals(shouldAttemptRecovery(storage), false);
+});
+
+Deno.test("clearRecoveryFlag removes the flag", () => {
+  const storage = fakeStorage();
+  markRecoveryAttempted(storage);
+  clearRecoveryFlag(storage);
+  assertEquals(shouldAttemptRecovery(storage), true);
+});
+
+Deno.test("shouldAttemptRecovery handles null storage gracefully", () => {
+  // Some environments (e.g. private browsing) may not expose storage.
+  assertEquals(shouldAttemptRecovery(null), false);
+});
+
+Deno.test("shouldAttemptRecovery handles throwing storage gracefully", () => {
+  const broken = {
+    getItem: () => {
+      throw new Error("storage disabled");
+    },
+  } as unknown as Storage;
+  assertEquals(shouldAttemptRecovery(broken), false);
+});
+
+Deno.test("markRecoveryAttempted handles throwing storage gracefully", () => {
+  const broken = {
+    setItem: () => {
+      throw new Error("storage disabled");
+    },
+  } as unknown as Storage;
+  // Should not throw.
+  markRecoveryAttempted(broken);
+});
+
+Deno.test("clearAllCaches deletes every cache key", async () => {
+  const caches = fakeCaches(["v1-static", "v1-runtime", "snapshots"]);
+  // deno-lint-ignore no-explicit-any
+  const deleted = await clearAllCaches(caches as any);
+  assertEquals(deleted.length, 3);
+  assert(deleted.includes("v1-static"));
+  assert(deleted.includes("v1-runtime"));
+  assert(deleted.includes("snapshots"));
+  assertEquals(caches.deletedKeys.length, 3);
+});
+
+Deno.test("clearAllCaches with no caches API returns empty list", async () => {
+  const deleted = await clearAllCaches(null);
+  assertEquals(deleted.length, 0);
+});
+
+Deno.test("unregisterAllServiceWorkers unregisters every registration", async () => {
+  const r1 = fakeRegistration();
+  const r2 = fakeRegistration();
+  const container = fakeSwContainer([r1, r2]);
+  const count = await unregisterAllServiceWorkers(container);
+  assertEquals(count, 2);
+  assert(r1.unregistered);
+  assert(r2.unregistered);
+});
+
+Deno.test("unregisterAllServiceWorkers handles missing container", async () => {
+  const count = await unregisterAllServiceWorkers(null);
+  assertEquals(count, 0);
+});
+
+Deno.test("recoverFromFailedAppLoad clears caches, unregisters SW, reloads", async () => {
+  const storage = fakeStorage();
+  const caches = fakeCaches(["v1-static", "snapshots"]);
+  const reg = fakeRegistration();
+  const swContainer = fakeSwContainer([reg]);
+  let reloaded = false;
+
+  const result = await recoverFromFailedAppLoad({
+    storage,
+    // deno-lint-ignore no-explicit-any
+    cachesApi: caches as any,
+    swContainer,
+    reload: () => {
+      reloaded = true;
+    },
+  });
+
+  assertEquals(result.recovered, true);
+  assertEquals(result.reason, "cleared-and-reloaded");
+  assertEquals(caches.deletedKeys.length, 2);
+  assert(reg.unregistered);
+  assert(reloaded, "reload should have been invoked");
+  // Flag must be set so a retry doesn't loop.
+  assertEquals(shouldAttemptRecovery(storage), false);
+});
+
+Deno.test("recoverFromFailedAppLoad refuses second attempt", async () => {
+  const storage = fakeStorage();
+  markRecoveryAttempted(storage);
+  const caches = fakeCaches(["v1-static"]);
+  const reg = fakeRegistration();
+  const swContainer = fakeSwContainer([reg]);
+  let reloaded = false;
+
+  const result = await recoverFromFailedAppLoad({
+    storage,
+    // deno-lint-ignore no-explicit-any
+    cachesApi: caches as any,
+    swContainer,
+    reload: () => {
+      reloaded = true;
+    },
+  });
+
+  assertEquals(result.recovered, false);
+  assertEquals(result.reason, "already-attempted");
+  assertEquals(caches.deletedKeys.length, 0);
+  assertEquals(reg.unregistered, false);
+  assertEquals(reloaded, false);
+});
+
+Deno.test("recoverFromFailedAppLoad with no storage still refuses (cannot guard against loop)", async () => {
+  const caches = fakeCaches(["v1-static"]);
+  const swContainer = fakeSwContainer([fakeRegistration()]);
+  let reloaded = false;
+
+  const result = await recoverFromFailedAppLoad({
+    storage: null,
+    // deno-lint-ignore no-explicit-any
+    cachesApi: caches as any,
+    swContainer,
+    reload: () => {
+      reloaded = true;
+    },
+  });
+
+  // Without storage we cannot detect loops, so we refuse to attempt
+  // recovery — otherwise we'd cause an infinite reload spiral.
+  assertEquals(result.recovered, false);
+  assertEquals(caches.deletedKeys.length, 0);
+  assertEquals(reloaded, false);
+});

--- a/tests/sw_static_files_test.ts
+++ b/tests/sw_static_files_test.ts
@@ -112,6 +112,38 @@ Deno.test("index.html has error handling for app module import", async () => {
   );
 });
 
+Deno.test("HTML entry points do not tell PWA users to clear browser cache (Issue #194)", async () => {
+  // The previous error message ("Failed to load app — please clear your
+  // browser cache and reload") was a dead end on installed PWAs (especially
+  // iOS), where there is no obvious cache to clear. The replacement is the
+  // automatic recovery path via docs/shared/pwa_recovery.js.
+  const entryPoints = [
+    repoPath("docs", "index.html"),
+    repoPath("docs", "graph", "index.html"),
+    repoPath("docs", "starfield", "index.html"),
+  ];
+  for (const path of entryPoints) {
+    const html = await Deno.readTextFile(path);
+    assert(
+      !html.includes("please clear your browser cache"),
+      `${path} must not instruct PWA users to clear the browser cache`,
+    );
+    assert(
+      html.includes("pwa_recovery.js"),
+      `${path} must wire up the PWA recovery helper`,
+    );
+  }
+});
+
+Deno.test("SW STATIC_FILES caches pwa_recovery.js (Issue #194)", async () => {
+  const swSource = await Deno.readTextFile(repoPath("docs", "sw.js"));
+  const staticFiles = parseStaticFiles(swSource);
+  assert(
+    staticFiles.includes("./shared/pwa_recovery.js"),
+    "sw.js STATIC_FILES must include ./shared/pwa_recovery.js so the recovery helper is reachable offline",
+  );
+});
+
 Deno.test("index.html shows initial loading status before JS runs", async () => {
   const html = await Deno.readTextFile(repoPath("docs", "index.html"));
   // The status element should have visible text content so users see


### PR DESCRIPTION
## Summary

The previous error path showed **"Failed to load app — please clear your browser cache and reload"** when a cached `app.js`/`graph.js` import failed. On an installed PWA — especially on iOS — that is a dead end: there is no obvious cache to clear without uninstalling the app, and the last cached model never gets a chance to render.

This change replaces the dead-end message with an automatic self-heal: clear every Cache Storage cache, unregister every Service Worker, and reload. A `sessionStorage` flag guards against an infinite recovery loop if the failure is not actually cache-related. Closes #194.

```mermaid
flowchart TD
    boot["Bootstrap script"] --> reg["Register Service Worker"]
    reg --> imp{"import app.js<br/>succeeds?"}
    imp -->|"yes"| app["App renders snapshot"]
    imp -->|"no — stale cache"| status["Status: Recovering — refreshing PWA caches…"]
    status --> rec["recoverFromFailedAppLoad()"]
    rec --> flag{"sessionStorage flag<br/>already set?"}
    flag -->|"no"| clear["Clear all caches +<br/>unregister SWs +<br/>reload"]
    flag -->|"yes"| reinstall["Status: remove the app and reinstall"]
    clear --> boot
```

## Files changed

- **New** `docs/shared/pwa_recovery.js` — dependency-injected recovery helper (testable in Deno).
- **New** `tests/pwa_recovery_test.ts` — 13 unit tests covering happy path, loop-guard, and graceful handling of missing `sessionStorage`/`caches`/`navigator.serviceWorker`.
- **Modified** `docs/index.html`, `docs/graph/index.html`, `docs/starfield/index.html` — wire the recovery helper into the import-failure path.
- **Modified** `docs/sw.js` — added `./shared/pwa_recovery.js` to `STATIC_FILES` so the helper is reachable offline.
- **Modified** `tests/sw_static_files_test.ts` — regression tests so the old wording can't sneak back in and so the helper stays precached.

## Test plan

- [x] `deno test -A tests/pwa_recovery_test.ts` — 13 new unit tests pass.
- [x] `./quality.sh` — full quality gate passes (fmt + lint + 466 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)