### PR TITLE
🟠 Stored XSS via unescaped neuron.type in inbound synapse renderer (docs/app.js:2514) (Issue #188)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -77,6 +77,7 @@ import { escapeHtml, extractTooltips } from "./shared/ui_helpers.js";
 import {
   buildObservationContributionsHtml,
 } from "./shared/observation_contributions.js";
+import { buildSynapseFromCellHtml } from "./shared/synapse_render.js";
 import {
   getInitialFocusTarget,
   installFocusTrap,
@@ -2492,10 +2493,7 @@ function renderSynapseList(toUuid, { animate = false } = {}) {
     }
 
     row.innerHTML = `
-      <div class="synapseFrom">
-        ${nameHtml}
-        <span class="neuronType">${fromType}</span>
-      </div>
+      ${buildSynapseFromCellHtml(nameHtml, fromType)}
       <div class="synapseStats">${statsHtml.join("")}</div>
       <div class="synapseNav">→</div>
     `;

--- a/docs/pr-summary-188.md
+++ b/docs/pr-summary-188.md
@@ -1,0 +1,29 @@
+## Summary
+Fixed a stored XSS in the inbound synapse renderer (`docs/app.js:2497`) where the source neuron's `type` field — populated directly from snapshot JSON loaded from a user-supplied URL — was interpolated into `innerHTML` without HTML escaping. A malicious snapshot containing `{"type":"<img src=x onerror=...>"}` could execute script in the `stsoftwareau.github.io` origin once the user opened an inbound-synapse list referencing that neuron.
+
+Closes #188.
+
+The synapseFrom-cell markup is now built by a new pure helper, `buildSynapseFromCellHtml` in `docs/shared/synapse_render.js`, which wraps the neuron `type` value in `escapeHtml(…)` — matching the treatment already given to every other snapshot-derived string in the same template. Centralising the markup in a DOM-free module also makes the escaping regression-testable under Deno.
+
+## Evidence
+This is a security fix for browser code; no UI change is visible. The regression is verified by unit tests that drive the new helper with attacker payloads and assert the output is escaped.
+
+Data flow before/after the fix:
+
+```mermaid
+flowchart LR
+    A[snapshot JSON<br/>creature.neurons[i].type] --> B[neuronsByUuid.get.type]
+    B --> C{renderSynapseList}
+    C -- before: raw interpolation --> D[innerHTML — XSS sink]
+    C -- after: buildSynapseFromCellHtml --> E[escapeHtml type] --> F[innerHTML — safe]
+```
+
+## Test Plan
+- Added `tests/synapse_render_test.ts` covering the new helper:
+  - escapes the `<img src=x onerror=alert(1)>` payload from the issue
+  - escapes ampersands and quotes in the `type` field
+  - passes pre-escaped `nameHtml` through verbatim (no double-escape)
+  - coerces non-string `type` values via `escapeHtml`
+  - wraps output in the `synapseFrom` container
+- Updated `docs/sw.js` STATIC_FILES to precache the new shared module (enforced by `tests/sw_static_files_test.ts`).
+- `./quality.sh` passes cleanly: 480 tests, 0 failures.

--- a/docs/pr-summary-188.md
+++ b/docs/pr-summary-188.md
@@ -1,12 +1,26 @@
 ## Summary
-Fixed a stored XSS in the inbound synapse renderer (`docs/app.js:2497`) where the source neuron's `type` field — populated directly from snapshot JSON loaded from a user-supplied URL — was interpolated into `innerHTML` without HTML escaping. A malicious snapshot containing `{"type":"<img src=x onerror=...>"}` could execute script in the `stsoftwareau.github.io` origin once the user opened an inbound-synapse list referencing that neuron.
+
+Fixed a stored XSS in the inbound synapse renderer (`docs/app.js:2497`) where
+the source neuron's `type` field — populated directly from snapshot JSON loaded
+from a user-supplied URL — was interpolated into `innerHTML` without HTML
+escaping. A malicious snapshot containing `{"type":"<img src=x onerror=...>"}`
+could execute script in the `stsoftwareau.github.io` origin once the user opened
+an inbound-synapse list referencing that neuron.
 
 Closes #188.
 
-The synapseFrom-cell markup is now built by a new pure helper, `buildSynapseFromCellHtml` in `docs/shared/synapse_render.js`, which wraps the neuron `type` value in `escapeHtml(…)` — matching the treatment already given to every other snapshot-derived string in the same template. Centralising the markup in a DOM-free module also makes the escaping regression-testable under Deno.
+The synapseFrom-cell markup is now built by a new pure helper,
+`buildSynapseFromCellHtml` in `docs/shared/synapse_render.js`, which wraps the
+neuron `type` value in `escapeHtml(…)` — matching the treatment already given to
+every other snapshot-derived string in the same template. Centralising the
+markup in a DOM-free module also makes the escaping regression-testable under
+Deno.
 
 ## Evidence
-This is a security fix for browser code; no UI change is visible. The regression is verified by unit tests that drive the new helper with attacker payloads and assert the output is escaped.
+
+This is a security fix for browser code; no UI change is visible. The regression
+is verified by unit tests that drive the new helper with attacker payloads and
+assert the output is escaped.
 
 Data flow before/after the fix:
 
@@ -19,11 +33,13 @@ flowchart LR
 ```
 
 ## Test Plan
+
 - Added `tests/synapse_render_test.ts` covering the new helper:
   - escapes the `<img src=x onerror=alert(1)>` payload from the issue
   - escapes ampersands and quotes in the `type` field
   - passes pre-escaped `nameHtml` through verbatim (no double-escape)
   - coerces non-string `type` values via `escapeHtml`
   - wraps output in the `synapseFrom` container
-- Updated `docs/sw.js` STATIC_FILES to precache the new shared module (enforced by `tests/sw_static_files_test.ts`).
+- Updated `docs/sw.js` STATIC_FILES to precache the new shared module (enforced
+  by `tests/sw_static_files_test.ts`).
 - `./quality.sh` passes cleanly: 480 tests, 0 failures.

--- a/docs/shared/synapse_render.js
+++ b/docs/shared/synapse_render.js
@@ -1,0 +1,32 @@
+/**
+ * Synapse row rendering helpers (Issue #188).
+ *
+ * Pure, DOM-free helpers used by docs/app.js to build the "synapseFrom"
+ * cell of an inbound-synapse row. All snapshot-derived strings (including
+ * the source neuron's `type` field, which an attacker can poison via a
+ * malicious snapshot URL) must be HTML-escaped before being interpolated
+ * into the row's `innerHTML`.
+ *
+ * This module is intentionally DOM-free so it can be unit-tested under
+ * Deno.
+ */
+
+import { escapeHtml } from "./ui_helpers.js";
+
+/**
+ * Build the HTML for the "synapseFrom" cell of an inbound-synapse row.
+ *
+ * `nameHtml` is assembled by the caller from already-escaped snapshot
+ * strings (alias, UUID) and is treated as trusted markup. `fromType` is
+ * a raw snapshot-derived value and is HTML-escaped here.
+ *
+ * @param {string} nameHtml — pre-escaped HTML fragment for the source name.
+ * @param {unknown} fromType — source neuron's `type` field (snapshot-derived).
+ * @returns {string} HTML string for the synapseFrom cell.
+ */
+export function buildSynapseFromCellHtml(nameHtml, fromType) {
+  return `<div class="synapseFrom">
+        ${nameHtml}
+        <span class="neuronType">${escapeHtml(fromType)}</span>
+      </div>`;
+}

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -57,6 +57,7 @@ const STATIC_FILES = [
   "./shared/modal_focus.js",
   "./shared/trace_header.js",
   "./shared/observation_contributions.js",
+  "./shared/synapse_render.js",
   "./shared/pwa_recovery.js",
   "./icons/icon-72x72.png",
   "./icons/icon-16x16.png",

--- a/tests/synapse_render_test.ts
+++ b/tests/synapse_render_test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for docs/shared/synapse_render.js (Issue #188).
+ *
+ * Regression coverage for the stored XSS in the inbound synapse list:
+ * the source neuron's `type` field comes from snapshot JSON loaded from
+ * a URL the visitor can be persuaded to supply, and was previously
+ * interpolated into `innerHTML` without escaping. Every snapshot-derived
+ * string in the "synapseFrom" cell must be HTML-escaped.
+ */
+
+import { assert, assertEquals } from "./test_helpers.ts";
+
+import { buildSynapseFromCellHtml } from "../docs/shared/synapse_render.js";
+
+Deno.test("buildSynapseFromCellHtml escapes neuron type", () => {
+  const html = buildSynapseFromCellHtml(
+    `<span class="neuronUuid">input-0</span>`,
+    "<img src=x onerror=alert(1)>",
+  );
+  // The attacker payload must not appear verbatim — the angle brackets
+  // and equals signs must be escaped.
+  assert(
+    !html.includes("<img src=x onerror=alert(1)>"),
+    "raw payload must not be present in output",
+  );
+  assert(
+    html.includes("&lt;img src=x onerror=alert(1)&gt;"),
+    "payload must be HTML-escaped",
+  );
+});
+
+Deno.test("buildSynapseFromCellHtml escapes ampersands and quotes in type", () => {
+  const html = buildSynapseFromCellHtml(
+    `<span class="neuronUuid">u</span>`,
+    `a & b "c" 'd'`,
+  );
+  assert(html.includes("a &amp; b &quot;c&quot; &#39;d&#39;"));
+});
+
+Deno.test("buildSynapseFromCellHtml preserves trusted nameHtml", () => {
+  // nameHtml is built by the caller from already-escaped snapshot strings,
+  // so the helper must not double-escape it.
+  const nameHtml = `<span class="neuronUuid">input-0</span>`;
+  const html = buildSynapseFromCellHtml(nameHtml, "input");
+  assert(html.includes(nameHtml), "nameHtml should be passed through verbatim");
+  assert(
+    html.includes(`<span class="neuronType">input</span>`),
+    "well-known type values render as a plain span",
+  );
+});
+
+Deno.test("buildSynapseFromCellHtml coerces non-string type", () => {
+  const html = buildSynapseFromCellHtml(`x`, null);
+  assert(html.includes(`<span class="neuronType">null</span>`));
+});
+
+Deno.test("buildSynapseFromCellHtml wraps in synapseFrom container", () => {
+  const html = buildSynapseFromCellHtml("name", "hidden");
+  // Sanity: the result contains the structural wrapper used by the CSS.
+  assertEquals(html.startsWith(`<div class="synapseFrom">`), true);
+  assertEquals(html.trimEnd().endsWith(`</div>`), true);
+});


### PR DESCRIPTION
## Summary
Fixed a stored XSS in the inbound synapse renderer (`docs/app.js:2497`) where the source neuron's `type` field — populated directly from snapshot JSON loaded from a user-supplied URL — was interpolated into `innerHTML` without HTML escaping. A malicious snapshot containing `{"type":"<img src=x onerror=...>"}` could execute script in the `stsoftwareau.github.io` origin once the user opened an inbound-synapse list referencing that neuron.

Closes #188.

The synapseFrom-cell markup is now built by a new pure helper, `buildSynapseFromCellHtml` in `docs/shared/synapse_render.js`, which wraps the neuron `type` value in `escapeHtml(…)` — matching the treatment already given to every other snapshot-derived string in the same template. Centralising the markup in a DOM-free module also makes the escaping regression-testable under Deno.

## Evidence
This is a security fix for browser code; no UI change is visible. The regression is verified by unit tests that drive the new helper with attacker payloads and assert the output is escaped.

Data flow before/after the fix:

```mermaid
flowchart LR
    A[snapshot JSON<br/>creature.neurons[i].type] --> B[neuronsByUuid.get.type]
    B --> C{renderSynapseList}
    C -- before: raw interpolation --> D[innerHTML — XSS sink]
    C -- after: buildSynapseFromCellHtml --> E[escapeHtml type] --> F[innerHTML — safe]
```

## Test Plan
- Added `tests/synapse_render_test.ts` covering the new helper:
  - escapes the `<img src=x onerror=alert(1)>` payload from the issue
  - escapes ampersands and quotes in the `type` field
  - passes pre-escaped `nameHtml` through verbatim (no double-escape)
  - coerces non-string `type` values via `escapeHtml`
  - wraps output in the `synapseFrom` container
- Updated `docs/sw.js` STATIC_FILES to precache the new shared module (enforced by `tests/sw_static_files_test.ts`).
- `./quality.sh` passes cleanly: 480 tests, 0 failures.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-188 -->