### PR TITLE
fix: resolve deno check errors in docs/evidence screenshot scripts (#209)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-209.md
+++ b/docs/archive/pr-summaries/pr-summary-209.md
@@ -1,0 +1,32 @@
+## Summary
+
+Fixed the five pre-existing `deno check` errors in `docs/evidence/_take_*.ts` so
+the repo-wide type-check planned in #203 can pass. Pinned `astral` to the
+already-cached `0.3.5` release across all three screenshot scripts and replaced
+the unsupported `page.screenshot({ path: ... })` option with the current API
+(`page.screenshot({ format: "png" })` returning PNG bytes that are written via
+`Deno.writeFile`). Closes #209.
+
+## Evidence
+
+CLI/backend change — no UI surface to screenshot. Verified by:
+
+- `deno check docs/evidence/` exits 0 (previously: 5 errors — 1×TS2307,
+  4×TS2353).
+- `deno check docs/` exits 0 (the broader-tree check that #203 will enable).
+- `./quality.sh` passes locally — 519 tests, 0 failures.
+- New regression test `tests/evidence_scripts_check_test.ts` runs
+  `deno check docs/evidence/` as a subprocess and asserts a zero exit code plus
+  absence of `TS2307`/`TS2353` strings in stderr.
+
+## Test Plan
+
+- Added `tests/evidence_scripts_check_test.ts` — spawns
+  `deno check docs/evidence/` and asserts exit code 0, guarding against any
+  future regression (unresolvable astral version, unsupported screenshot option,
+  etc.).
+- Confirmed every `page.screenshot` call in the three scripts still produces the
+  same output PNG path it did before, only via `Deno.writeFile` instead of the
+  removed `path` option.
+- `./quality.sh` passes: `deno fmt --check`, `deno lint`,
+  `deno check helpers/ scripts/ tests/`, `deno test -A` all green.

--- a/docs/evidence/_take_loading_fix.ts
+++ b/docs/evidence/_take_loading_fix.ts
@@ -1,4 +1,4 @@
-import { launch } from "https://deno.land/x/astral@0.4.10/mod.ts";
+import { launch } from "https://deno.land/x/astral@0.3.5/mod.ts";
 
 const EVIDENCE_DIR =
   "/Users/nigel/auto-issue-work/NEAT-AI-Explore/docs/evidence";
@@ -10,18 +10,19 @@ console.log("Navigating to app...");
 const page = await browser.newPage("http://localhost:8765/");
 await new Promise((r) => setTimeout(r, 2000));
 console.log("Taking loading state screenshot...");
-await page.screenshot({
-  path: `${EVIDENCE_DIR}/loading-status-indicator.png`,
-});
+const loadingShot = await page.screenshot({ format: "png" });
+await Deno.writeFile(
+  `${EVIDENCE_DIR}/loading-status-indicator.png`,
+  loadingShot,
+);
 console.log("Saved loading-status-indicator.png");
 
 // Screenshot 2: After snapshot loads
 console.log("Waiting for snapshot to load...");
 await new Promise((r) => setTimeout(r, 15000));
 console.log("Taking loaded state screenshot...");
-await page.screenshot({
-  path: `${EVIDENCE_DIR}/loading-complete.png`,
-});
+const loadedShot = await page.screenshot({ format: "png" });
+await Deno.writeFile(`${EVIDENCE_DIR}/loading-complete.png`, loadedShot);
 console.log("Saved loading-complete.png");
 await page.close();
 

--- a/docs/evidence/_take_loading_screenshots.ts
+++ b/docs/evidence/_take_loading_screenshots.ts
@@ -1,4 +1,4 @@
-import { launch } from "https://deno.land/x/astral/mod.ts";
+import { launch } from "https://deno.land/x/astral@0.3.5/mod.ts";
 
 const EVIDENCE_DIR =
   "/Users/nigel/auto-issue-work/NEAT-AI-Explore/docs/evidence";
@@ -11,18 +11,19 @@ const page = await browser.newPage("http://localhost:8765/");
 // Brief wait for HTML to render but before snapshot finishes loading
 await new Promise((r) => setTimeout(r, 1500));
 console.log("Taking loading state screenshot...");
-await page.screenshot({
-  path: `${EVIDENCE_DIR}/loading-status-indicator.png`,
-});
+const loadingShot = await page.screenshot({ format: "png" });
+await Deno.writeFile(
+  `${EVIDENCE_DIR}/loading-status-indicator.png`,
+  loadingShot,
+);
 console.log("Saved loading-status-indicator.png");
 
 // Screenshot 2: After snapshot loads (shows loaded state)
 console.log("Waiting for snapshot to load...");
 await new Promise((r) => setTimeout(r, 15000));
 console.log("Taking loaded state screenshot...");
-await page.screenshot({
-  path: `${EVIDENCE_DIR}/loading-complete.png`,
-});
+const loadedShot = await page.screenshot({ format: "png" });
+await Deno.writeFile(`${EVIDENCE_DIR}/loading-complete.png`, loadedShot);
 console.log("Saved loading-complete.png");
 await page.close();
 

--- a/docs/evidence/_take_screenshots.ts
+++ b/docs/evidence/_take_screenshots.ts
@@ -1,4 +1,7 @@
-import { launch } from "https://deno.land/x/astral/mod.ts";
+import { launch } from "https://deno.land/x/astral@0.3.5/mod.ts";
+
+const EVIDENCE_DIR =
+  "/Users/nigel/auto-issue-work/NEAT-AI-Explore/docs/evidence";
 
 const browser = await launch();
 
@@ -8,10 +11,8 @@ const tracePage = await browser.newPage("http://localhost:8765/");
 // Wait for the snapshot to load - give it time to fetch and render
 await new Promise((r) => setTimeout(r, 5000));
 console.log("Taking trace explorer screenshot...");
-await tracePage.screenshot({
-  path:
-    "/Users/nigel/auto-issue-work/NEAT-AI-Explore/docs/evidence/trace-synapse-colours.png",
-});
+const traceShot = await tracePage.screenshot({ format: "png" });
+await Deno.writeFile(`${EVIDENCE_DIR}/trace-synapse-colours.png`, traceShot);
 console.log("Saved trace-synapse-colours.png");
 await tracePage.close();
 
@@ -21,10 +22,8 @@ const graphPage = await browser.newPage("http://localhost:8765/graph/");
 // Wait for graph to render
 await new Promise((r) => setTimeout(r, 5000));
 console.log("Taking graph explorer screenshot...");
-await graphPage.screenshot({
-  path:
-    "/Users/nigel/auto-issue-work/NEAT-AI-Explore/docs/evidence/graph-synapse-colours.png",
-});
+const graphShot = await graphPage.screenshot({ format: "png" });
+await Deno.writeFile(`${EVIDENCE_DIR}/graph-synapse-colours.png`, graphShot);
 console.log("Saved graph-synapse-colours.png");
 await graphPage.close();
 

--- a/tests/evidence_scripts_check_test.ts
+++ b/tests/evidence_scripts_check_test.ts
@@ -1,0 +1,38 @@
+/**
+ * Issue #209 — Regression guard for docs/evidence/_take_*.ts.
+ *
+ * Runs `deno check docs/evidence/` as a subprocess and asserts a zero exit
+ * code so any future regression in the screenshot scripts (e.g. an
+ * unresolvable astral version or another unsupported screenshot option) is
+ * caught by CI.
+ */
+
+import { assert, assertEquals } from "./test_helpers.ts";
+
+const REPO_ROOT = new URL("..", import.meta.url);
+
+Deno.test("deno check docs/evidence/ exits cleanly", async () => {
+  const cmd = new Deno.Command("deno", {
+    args: ["check", "docs/evidence/"],
+    cwd: REPO_ROOT,
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { code, stderr } = await cmd.output();
+  const stderrText = new TextDecoder().decode(stderr);
+
+  assertEquals(
+    code,
+    0,
+    `expected 'deno check docs/evidence/' to succeed but got exit ${code}\n${stderrText}`,
+  );
+  assert(
+    !stderrText.includes("TS2307"),
+    `unexpected TS2307 module resolution error:\n${stderrText}`,
+  );
+  assert(
+    !stderrText.includes("TS2353"),
+    `unexpected TS2353 unknown-property error:\n${stderrText}`,
+  );
+});


### PR DESCRIPTION
## Summary

Fixed the five pre-existing `deno check` errors in `docs/evidence/_take_*.ts` so
the repo-wide type-check planned in #203 can pass. Pinned `astral` to the
already-cached `0.3.5` release across all three screenshot scripts and replaced
the unsupported `page.screenshot({ path: ... })` option with the current API
(`page.screenshot({ format: "png" })` returning PNG bytes that are written via
`Deno.writeFile`). Closes #209.

## Evidence

CLI/backend change — no UI surface to screenshot. Verified by:

- `deno check docs/evidence/` exits 0 (previously: 5 errors — 1×TS2307,
  4×TS2353).
- `deno check docs/` exits 0 (the broader-tree check that #203 will enable).
- `./quality.sh` passes locally — 519 tests, 0 failures.
- New regression test `tests/evidence_scripts_check_test.ts` runs
  `deno check docs/evidence/` as a subprocess and asserts a zero exit code plus
  absence of `TS2307`/`TS2353` strings in stderr.

## Test Plan

- Added `tests/evidence_scripts_check_test.ts` — spawns
  `deno check docs/evidence/` and asserts exit code 0, guarding against any
  future regression (unresolvable astral version, unsupported screenshot option,
  etc.).
- Confirmed every `page.screenshot` call in the three scripts still produces the
  same output PNG path it did before, only via `Deno.writeFile` instead of the
  removed `path` option.
- `./quality.sh` passes: `deno fmt --check`, `deno lint`,
  `deno check helpers/ scripts/ tests/`, `deno test -A` all green.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-209 -->