### PR TITLE
Pin semgrep container image to sha256 digest (#256)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -11,7 +11,11 @@ jobs:
   semgrep:
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep
+      # Pinned to semgrep/semgrep 1.163.0 (Issue #256). The multi-arch
+      # manifest digest below is immutable; an unpinned tag resolves at
+      # runtime and exposes SEMGREP_APP_TOKEN to whatever the Semgrep
+      # Docker Hub account last pushed. Rotate via bump-deps automation.
+      image: semgrep/semgrep@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
     steps:
       # actions/checkout@v4.2.2
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/docs/archive/pr-summaries/pr-summary-256.md
+++ b/docs/archive/pr-summaries/pr-summary-256.md
@@ -1,0 +1,39 @@
+## Summary
+
+Pinned the `semgrep/semgrep` container image in `.github/workflows/semgrep.yml`
+to an immutable multi-arch manifest digest, matching the pattern already in
+use in the sister repo `stSoftwareAU/NEAT-AI-Discovery`. The previous
+declaration `image: semgrep/semgrep` resolved to whatever tag the Semgrep
+maintainers (or anyone who compromised the Semgrep Docker Hub account) last
+pushed — exposing `SEMGREP_APP_TOKEN` to whatever code the upstream image
+contained at runtime. Closes #256.
+
+The chosen digest is
+`sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03`
+(semgrep/semgrep 1.163.0), which is the digest the sister repo already
+pins to.
+
+## Evidence
+
+This is a backend/CI-only change — no UI surface to screenshot. Verification
+is via the new unit test which asserts the workflow's container image is
+pinned in the form `semgrep/semgrep@sha256:<64-hex>`:
+
+```
+running 7 tests from ./tests/semgrep_workflow_test.ts
+semgrep workflow file exists ... ok
+semgrep workflow is valid YAML and named correctly ... ok
+semgrep workflow triggers on pull_request ... ok
+semgrep workflow uses minimal contents:read permissions ... ok
+semgrep workflow runs in the semgrep container ... ok
+semgrep container image is pinned to a sha256 digest (#256) ... ok
+semgrep workflow checks out and runs semgrep ci ... ok
+ok | 7 passed | 0 failed
+```
+
+The full quality gate (`./quality.sh`) passes with 729 tests.
+
+## Test Plan
+
+- Added `tests/semgrep_workflow_test.ts::semgrep container image is pinned to a sha256 digest (#256)` — asserts `jobs.semgrep.container.image` matches the regex `^semgrep/semgrep@sha256:[0-9a-f]{64}$`. This test fails against the pre-fix workflow (where the image was the bare reference `semgrep/semgrep`) and passes against the pinned form.
+- Loosened the existing "runs in the semgrep container" assertion from an exact-string equality to a `startsWith` check, since the canonical image reference now includes a digest suffix.

--- a/tests/semgrep_workflow_test.ts
+++ b/tests/semgrep_workflow_test.ts
@@ -70,10 +70,30 @@ Deno.test("semgrep workflow runs in the semgrep container", async () => {
 
   const container = job!.container;
   const image = typeof container === "string" ? container : container?.image;
-  assertEquals(
-    image,
-    "semgrep/semgrep",
+  assert(
+    typeof image === "string" && image.startsWith("semgrep/semgrep"),
     "job must run inside the semgrep/semgrep container image",
+  );
+});
+
+Deno.test("semgrep container image is pinned to a sha256 digest (#256)", async () => {
+  // An unpinned `image: semgrep/semgrep` resolves to whatever the maintainers
+  // (or anyone who hijacks the Docker Hub account) last pushed at runtime,
+  // exposing SEMGREP_APP_TOKEN to malicious code. Pin to an immutable
+  // multi-arch manifest digest so the resolved image is locked in.
+  const wf = await loadWorkflow();
+  const job = wf.jobs?.semgrep;
+  assert(job, "expected a 'semgrep' job");
+
+  const container = job!.container;
+  const image = typeof container === "string" ? container : container?.image;
+  assert(typeof image === "string", "container.image must be a string");
+
+  const match = image!.match(/^semgrep\/semgrep@sha256:([0-9a-f]{64})$/);
+  assert(
+    match !== null,
+    `container.image must be pinned as 'semgrep/semgrep@sha256:<64-hex>' ` +
+      `but got '${image}'`,
   );
 });
 


### PR DESCRIPTION
## Summary

Pinned the `semgrep/semgrep` container image in `.github/workflows/semgrep.yml`
to an immutable multi-arch manifest digest, matching the pattern already in
use in the sister repo `stSoftwareAU/NEAT-AI-Discovery`. The previous
declaration `image: semgrep/semgrep` resolved to whatever tag the Semgrep
maintainers (or anyone who compromised the Semgrep Docker Hub account) last
pushed — exposing `SEMGREP_APP_TOKEN` to whatever code the upstream image
contained at runtime. Closes #256.

The chosen digest is
`sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03`
(semgrep/semgrep 1.163.0), which is the digest the sister repo already
pins to.

## Evidence

This is a backend/CI-only change — no UI surface to screenshot. Verification
is via the new unit test which asserts the workflow's container image is
pinned in the form `semgrep/semgrep@sha256:<64-hex>`:

```
running 7 tests from ./tests/semgrep_workflow_test.ts
semgrep workflow file exists ... ok
semgrep workflow is valid YAML and named correctly ... ok
semgrep workflow triggers on pull_request ... ok
semgrep workflow uses minimal contents:read permissions ... ok
semgrep workflow runs in the semgrep container ... ok
semgrep container image is pinned to a sha256 digest (#256) ... ok
semgrep workflow checks out and runs semgrep ci ... ok
ok | 7 passed | 0 failed
```

The full quality gate (`./quality.sh`) passes with 729 tests.

## Test Plan

- Added `tests/semgrep_workflow_test.ts::semgrep container image is pinned to a sha256 digest (#256)` — asserts `jobs.semgrep.container.image` matches the regex `^semgrep/semgrep@sha256:[0-9a-f]{64}$`. This test fails against the pre-fix workflow (where the image was the bare reference `semgrep/semgrep`) and passes against the pinned form.
- Loosened the existing "runs in the semgrep container" assertion from an exact-string equality to a `startsWith` check, since the canonical image reference now includes a digest suffix.



## Milestone
This PR is part of the **audit issues** milestone and targets the `milestone/audit-issues` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-256 -->