### PR TITLE
Add timeout-minutes to every workflow job (#257)

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -18,6 +18,9 @@ permissions:
 jobs:
   a11y:
     runs-on: ubuntu-latest
+    # Cap the runner so a wedged http-server / pa11y-ci page load cannot hold
+    # the runner for the GitHub default of 360 minutes (#257).
+    timeout-minutes: 15
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   quality:
     runs-on: ubuntu-latest
+    # Cap the runner so a wedged deno test / type check cannot hold the
+    # runner for the GitHub default of 360 minutes (#257).
+    timeout-minutes: 20
     steps:
       - name: Checkout
         # actions/checkout@v4.2.2

--- a/.github/workflows/deno-quality.yml
+++ b/.github/workflows/deno-quality.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   quality:
     runs-on: ubuntu-latest
+    # Cap the runner so a wedged deno test / coverage upload cannot hold the
+    # runner for the GitHub default of 360 minutes (#257).
+    timeout-minutes: 20
     steps:
       # actions/checkout@v5.0.1
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    # Cap the runner so a wedged dependency-review-action cannot hold the
+    # runner for the GitHub default of 360 minutes (#257).
+    timeout-minutes: 5
     steps:
       # actions/checkout@v4.2.2
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,9 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Cap the runner so a wedged Pages deploy cannot hold the runner for the
+    # GitHub default of 360 minutes (#257).
+    timeout-minutes: 15
     steps:
       - name: Checkout
         # actions/checkout@v4.2.2

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -17,6 +17,9 @@ permissions:
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
+    # Cap the runner so a wedged gitleaks scan cannot hold the runner for the
+    # GitHub default of 360 minutes (#257).
+    timeout-minutes: 10
     steps:
       # actions/checkout@v4.2.2
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   markdownlint:
     runs-on: ubuntu-latest
+    # Cap the runner so a wedged markdownlint scan cannot hold the runner
+    # for the GitHub default of 360 minutes (#257).
+    timeout-minutes: 5
     steps:
       # actions/checkout@v4
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   semgrep:
     runs-on: ubuntu-latest
+    # Cap the runner so a wedged semgrep scan cannot hold the runner for the
+    # GitHub default of 360 minutes (#257).
+    timeout-minutes: 15
     container:
       # Pinned to semgrep/semgrep 1.163.0 (Issue #256). The multi-arch
       # manifest digest below is immutable; an unpinned tag resolves at

--- a/.github/workflows/semver-bump.yml
+++ b/.github/workflows/semver-bump.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   update-version:
     runs-on: ubuntu-latest
+    # Cap the runner so a wedged version bump / push cannot hold the runner
+    # for the GitHub default of 360 minutes (#257).
+    timeout-minutes: 10
     permissions:
       contents: write
     if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref != 'Develop'

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
+    # Cap the runner so a wedged shellcheck scan cannot hold the runner for
+    # the GitHub default of 360 minutes (#257).
+    timeout-minutes: 5
     steps:
       # actions/checkout@v4.2.2
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -16,6 +16,9 @@ jobs:
   upgrade:
     name: Upgrade dependencies and create PR
     runs-on: ubuntu-latest
+    # Cap the runner so a wedged `deno outdated --update` or registry hang
+    # cannot hold the runner for the GitHub default of 360 minutes (#257).
+    timeout-minutes: 30
     steps:
       - name: Checkout
         # actions/checkout@v4.2.2 — pinned to a 40-char commit SHA so a

--- a/docs/archive/pr-summaries/pr-summary-256.md
+++ b/docs/archive/pr-summaries/pr-summary-256.md
@@ -1,23 +1,22 @@
 ## Summary
 
 Pinned the `semgrep/semgrep` container image in `.github/workflows/semgrep.yml`
-to an immutable multi-arch manifest digest, matching the pattern already in
-use in the sister repo `stSoftwareAU/NEAT-AI-Discovery`. The previous
-declaration `image: semgrep/semgrep` resolved to whatever tag the Semgrep
-maintainers (or anyone who compromised the Semgrep Docker Hub account) last
-pushed — exposing `SEMGREP_APP_TOKEN` to whatever code the upstream image
-contained at runtime. Closes #256.
+to an immutable multi-arch manifest digest, matching the pattern already in use
+in the sister repo `stSoftwareAU/NEAT-AI-Discovery`. The previous declaration
+`image: semgrep/semgrep` resolved to whatever tag the Semgrep maintainers (or
+anyone who compromised the Semgrep Docker Hub account) last pushed — exposing
+`SEMGREP_APP_TOKEN` to whatever code the upstream image contained at runtime.
+Closes #256.
 
 The chosen digest is
 `sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03`
-(semgrep/semgrep 1.163.0), which is the digest the sister repo already
-pins to.
+(semgrep/semgrep 1.163.0), which is the digest the sister repo already pins to.
 
 ## Evidence
 
-This is a backend/CI-only change — no UI surface to screenshot. Verification
-is via the new unit test which asserts the workflow's container image is
-pinned in the form `semgrep/semgrep@sha256:<64-hex>`:
+This is a backend/CI-only change — no UI surface to screenshot. Verification is
+via the new unit test which asserts the workflow's container image is pinned in
+the form `semgrep/semgrep@sha256:<64-hex>`:
 
 ```
 running 7 tests from ./tests/semgrep_workflow_test.ts
@@ -35,5 +34,12 @@ The full quality gate (`./quality.sh`) passes with 729 tests.
 
 ## Test Plan
 
-- Added `tests/semgrep_workflow_test.ts::semgrep container image is pinned to a sha256 digest (#256)` — asserts `jobs.semgrep.container.image` matches the regex `^semgrep/semgrep@sha256:[0-9a-f]{64}$`. This test fails against the pre-fix workflow (where the image was the bare reference `semgrep/semgrep`) and passes against the pinned form.
-- Loosened the existing "runs in the semgrep container" assertion from an exact-string equality to a `startsWith` check, since the canonical image reference now includes a digest suffix.
+- Added
+  `tests/semgrep_workflow_test.ts::semgrep container image is pinned to a sha256 digest (#256)`
+  — asserts `jobs.semgrep.container.image` matches the regex
+  `^semgrep/semgrep@sha256:[0-9a-f]{64}$`. This test fails against the pre-fix
+  workflow (where the image was the bare reference `semgrep/semgrep`) and passes
+  against the pinned form.
+- Loosened the existing "runs in the semgrep container" assertion from an
+  exact-string equality to a `startsWith` check, since the canonical image
+  reference now includes a digest suffix.

--- a/docs/archive/pr-summaries/pr-summary-257.md
+++ b/docs/archive/pr-summaries/pr-summary-257.md
@@ -1,0 +1,71 @@
+## Summary
+
+Added an explicit `timeout-minutes:` cap to every job across the eleven
+workflows in `.github/workflows/`. Without it, a wedged step (a stuck
+`http-server` + `pa11y-ci`, a hanging `deno test` against a flaky network
+resource, a stalled `deno outdated --update`) holds a runner for the GitHub
+default of 360 minutes (6 hours) and starves runner capacity. An explicit
+per-job cap surfaces hangs as fast failures.
+
+Caps applied (following the issue's suggested ranges — 5 minutes for lint/scan,
+15–20 minutes for Deno test/coverage, 30 minutes for the weekly upgrade):
+
+| Workflow                   | Job                 | timeout-minutes |
+| -------------------------- | ------------------- | --------------- |
+| `a11y.yml`                 | `a11y`              | 15              |
+| `ci.yml`                   | `quality`           | 20              |
+| `deno-quality.yml`         | `quality`           | 20              |
+| `dependency-review.yml`    | `dependency-review` | 5               |
+| `deploy.yml`               | `deploy`            | 15              |
+| `gitleaks.yml`             | `gitleaks`          | 10              |
+| `markdown-lint.yml`        | `markdownlint`      | 5               |
+| `semgrep.yml`              | `semgrep`           | 15              |
+| `semver-bump.yml`          | `update-version`    | 10              |
+| `shellcheck.yml`           | `shellcheck`        | 5               |
+| `upgrade-dependencies.yml` | `upgrade`           | 30              |
+
+A new repo-wide test enforces the policy so any future workflow added without a
+`timeout-minutes:` cap fails CI. Closes #257.
+
+## Evidence
+
+This is a CI-only change — no UI to screenshot. Verification is via the new
+repo-wide test which fails against the pre-fix workflow set (every job missing
+`timeout-minutes`) and passes once the caps are added.
+
+Before:
+
+```text
+running 1 test from ./tests/workflow_job_timeout_test.ts
+every workflow job declares timeout-minutes (#257) ... FAILED
+error: Workflow jobs missing or with invalid timeout-minutes:
+  a11y.yml: job 'a11y' is missing timeout-minutes
+  ci.yml: job 'quality' is missing timeout-minutes
+  ... (11 jobs total)
+```
+
+After:
+
+```text
+running 1 test from ./tests/workflow_job_timeout_test.ts
+every workflow job declares timeout-minutes (#257) ... ok (6ms)
+
+ok | 730 passed | 0 failed (3s)
+```
+
+## Test Plan
+
+- Added
+  `tests/workflow_job_timeout_test.ts::every workflow job declares
+  timeout-minutes (#257)`
+  — walks every `.yml`/`.yaml` file in `.github/workflows/`, parses each as
+  YAML, and asserts every job has a positive-integer `timeout-minutes` no
+  greater than 60 minutes. Fails against the pre-fix workflow set; passes after.
+- `./quality.sh` — full quality gate (`deno fmt --check`, `deno lint`,
+  `deno check`, `deno test -A`) passes cleanly with 730 tests.
+
+## Out-of-scope edit
+
+`docs/archive/pr-summaries/pr-summary-256.md` had a pre-existing `deno fmt`
+failure (line wrapping) that was blocking `quality.sh`. Auto-formatted via
+`deno fmt` — no content change.

--- a/tests/workflow_job_timeout_test.ts
+++ b/tests/workflow_job_timeout_test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the workflow job timeout policy (#257).
+ *
+ * Every job in every `.github/workflows/*.yml` file must declare an explicit
+ * `timeout-minutes:` cap so a wedged step cannot hold a runner for the
+ * GitHub default of 360 minutes (6 hours). An explicit per-job cap surfaces
+ * hangs as fast failures and frees runner capacity.
+ *
+ * The cap must be a positive integer and must not exceed 60 minutes — none
+ * of the jobs in this repository legitimately need more time, and the
+ * weekly upgrade workflow is the upper bound at 30 minutes.
+ */
+
+import { parse as parseYaml } from "@std/yaml";
+import { assert } from "./test_helpers.ts";
+
+interface WorkflowJob {
+  "timeout-minutes"?: number;
+}
+
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>;
+}
+
+const WORKFLOWS_DIR = new URL("../.github/workflows/", import.meta.url);
+const MAX_TIMEOUT_MINUTES = 60;
+
+async function listWorkflowFiles(): Promise<string[]> {
+  const files: string[] = [];
+  for await (const entry of Deno.readDir(WORKFLOWS_DIR)) {
+    if (!entry.isFile) continue;
+    if (!entry.name.endsWith(".yml") && !entry.name.endsWith(".yaml")) continue;
+    files.push(entry.name);
+  }
+  files.sort();
+  return files;
+}
+
+async function loadWorkflow(name: string): Promise<Workflow> {
+  const url = new URL(name, WORKFLOWS_DIR);
+  const text = await Deno.readTextFile(url);
+  return parseYaml(text) as Workflow;
+}
+
+Deno.test("every workflow job declares timeout-minutes (#257)", async () => {
+  const files = await listWorkflowFiles();
+  assert(files.length > 0, "expected at least one workflow file");
+
+  const failures: string[] = [];
+  for (const file of files) {
+    const wf = await loadWorkflow(file);
+    const jobs = wf.jobs ?? {};
+    for (const [jobName, job] of Object.entries(jobs)) {
+      const timeout = job?.["timeout-minutes"];
+      if (typeof timeout !== "number") {
+        failures.push(`${file}: job '${jobName}' is missing timeout-minutes`);
+        continue;
+      }
+      if (!Number.isInteger(timeout) || timeout <= 0) {
+        failures.push(
+          `${file}: job '${jobName}' has invalid timeout-minutes: ${timeout}`,
+        );
+        continue;
+      }
+      if (timeout > MAX_TIMEOUT_MINUTES) {
+        failures.push(
+          `${file}: job '${jobName}' timeout-minutes (${timeout}) exceeds cap ` +
+            `of ${MAX_TIMEOUT_MINUTES}`,
+        );
+      }
+    }
+  }
+
+  assert(
+    failures.length === 0,
+    `Workflow jobs missing or with invalid timeout-minutes:\n  ${
+      failures.join("\n  ")
+    }`,
+  );
+});


### PR DESCRIPTION
## Summary

Added an explicit `timeout-minutes:` cap to every job across the eleven
workflows in `.github/workflows/`. Without it, a wedged step (a stuck
`http-server` + `pa11y-ci`, a hanging `deno test` against a flaky network
resource, a stalled `deno outdated --update`) holds a runner for the GitHub
default of 360 minutes (6 hours) and starves runner capacity. An explicit
per-job cap surfaces hangs as fast failures.

Caps applied (following the issue's suggested ranges — 5 minutes for lint/scan,
15–20 minutes for Deno test/coverage, 30 minutes for the weekly upgrade):

| Workflow                   | Job                 | timeout-minutes |
| -------------------------- | ------------------- | --------------- |
| `a11y.yml`                 | `a11y`              | 15              |
| `ci.yml`                   | `quality`           | 20              |
| `deno-quality.yml`         | `quality`           | 20              |
| `dependency-review.yml`    | `dependency-review` | 5               |
| `deploy.yml`               | `deploy`            | 15              |
| `gitleaks.yml`             | `gitleaks`          | 10              |
| `markdown-lint.yml`        | `markdownlint`      | 5               |
| `semgrep.yml`              | `semgrep`           | 15              |
| `semver-bump.yml`          | `update-version`    | 10              |
| `shellcheck.yml`           | `shellcheck`        | 5               |
| `upgrade-dependencies.yml` | `upgrade`           | 30              |

A new repo-wide test enforces the policy so any future workflow added without a
`timeout-minutes:` cap fails CI. Closes #257.

## Evidence

This is a CI-only change — no UI to screenshot. Verification is via the new
repo-wide test which fails against the pre-fix workflow set (every job missing
`timeout-minutes`) and passes once the caps are added.

Before:

```text
running 1 test from ./tests/workflow_job_timeout_test.ts
every workflow job declares timeout-minutes (#257) ... FAILED
error: Workflow jobs missing or with invalid timeout-minutes:
  a11y.yml: job 'a11y' is missing timeout-minutes
  ci.yml: job 'quality' is missing timeout-minutes
  ... (11 jobs total)
```

After:

```text
running 1 test from ./tests/workflow_job_timeout_test.ts
every workflow job declares timeout-minutes (#257) ... ok (6ms)

ok | 730 passed | 0 failed (3s)
```

## Test Plan

- Added
  `tests/workflow_job_timeout_test.ts::every workflow job declares
  timeout-minutes (#257)`
  — walks every `.yml`/`.yaml` file in `.github/workflows/`, parses each as
  YAML, and asserts every job has a positive-integer `timeout-minutes` no
  greater than 60 minutes. Fails against the pre-fix workflow set; passes after.
- `./quality.sh` — full quality gate (`deno fmt --check`, `deno lint`,
  `deno check`, `deno test -A`) passes cleanly with 730 tests.

## Out-of-scope edit

`docs/archive/pr-summaries/pr-summary-256.md` had a pre-existing `deno fmt`
failure (line wrapping) that was blocking `quality.sh`. Auto-formatted via
`deno fmt` — no content change.



## Milestone
This PR is part of the **audit issues** milestone and targets the `milestone/audit-issues` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-257 -->