### PR TITLE
Add concurrency groups to PR-triggered workflows (#258)

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -12,6 +12,14 @@ on:
   push:
     branches: [Develop]
 
+# Cancel superseded runs when a PR receives a new commit so the latest push
+# gets feedback fastest and we do not waste runner minutes on stale work
+# (#258). The group keys on workflow + ref so PR and Develop runs do not
+# cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/deno-quality.yml
+++ b/.github/workflows/deno-quality.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches: ["*"]
 
+# Cancel superseded runs when a PR receives a new commit so the latest push
+# gets feedback fastest and we do not waste runner minutes on stale work
+# (#258).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches: ["*"]
 
+# Cancel superseded runs when a PR receives a new commit so the latest push
+# gets feedback fastest and we do not waste runner minutes on stale work
+# (#258).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,6 +11,13 @@ on:
   pull_request:
     branches: ["*"]
 
+# Cancel superseded runs when a PR receives a new commit so the latest push
+# gets feedback fastest and we do not waste runner minutes on stale work
+# (#258).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -6,6 +6,14 @@ on:
   push:
     branches: [main, master, Develop]
 
+# Cancel superseded runs when a PR receives a new commit so the latest push
+# gets feedback fastest and we do not waste runner minutes on stale work
+# (#258). The group keys on workflow + ref so PR and branch-push runs do not
+# cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches: ["*"]
 
+# Cancel superseded runs when a PR receives a new commit so the latest push
+# gets feedback fastest and we do not waste runner minutes on stale work
+# (#258).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/semver-bump.yml
+++ b/.github/workflows/semver-bump.yml
@@ -6,6 +6,13 @@ on:
     branches:
       - Develop
 
+# Cancel superseded runs when a PR receives a new commit so the latest push
+# gets feedback fastest and we do not waste runner minutes on stale work
+# (#258).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches: ["*"]
 
+# Cancel superseded runs when a PR receives a new commit so the latest push
+# gets feedback fastest and we do not waste runner minutes on stale work
+# (#258).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/docs/archive/pr-summaries/pr-summary-258.md
+++ b/docs/archive/pr-summaries/pr-summary-258.md
@@ -1,0 +1,66 @@
+## Summary
+
+Added workflow-level `concurrency:` blocks to every PR-triggered workflow in
+`.github/workflows/` so superseded runs are cancelled when a contributor
+pushes new commits to a PR. Each block keys on
+{% raw %}`${{ github.workflow }}-${{ github.ref }}`{% endraw %} with
+`cancel-in-progress: true` — the canonical pattern. The Pages
+deploy workflow keeps its existing `group: "pages"` /
+`cancel-in-progress: false` policy because Pages deploys must serialise.
+Closes #258.
+
+The issue listed `ci.yml`, but it does not exist in this repo — it was
+consolidated into `deno-quality.yml` under Issue #259, so that file picked
+up the concurrency block in its place. `upgrade-dependencies.yml` is
+schedule / `workflow_dispatch` only (not PR-triggered) so it is not in
+scope.
+
+## Workflows updated
+
+- `a11y.yml`
+- `deno-quality.yml`
+- `dependency-review.yml`
+- `gitleaks.yml`
+- `markdown-lint.yml`
+- `semgrep.yml`
+- `semver-bump.yml`
+- `shellcheck.yml`
+
+`deploy.yml` is unchanged.
+
+## Evidence
+
+Backend / CI-config change with no UI surface, so no screenshot. Behaviour
+is verified by the new test in `tests/workflow_concurrency_test.ts`, which
+parses every workflow YAML and asserts that PR-triggered ones declare the
+canonical concurrency block while `deploy.yml` keeps its Pages-serialising
+policy.
+
+```mermaid
+sequenceDiagram
+    participant Dev as Contributor
+    participant GH as GitHub
+    participant Run1 as Run #N (older)
+    participant Run2 as Run #N+1 (latest)
+    Dev->>GH: push commit A
+    GH->>Run1: start workflow
+    Dev->>GH: push commit B (supersedes A)
+    GH->>Run2: start workflow
+    GH-->>Run1: cancel-in-progress (same group)
+    Run2->>Dev: feedback on latest commit
+```
+
+## Test Plan
+
+- Added `tests/workflow_concurrency_test.ts` with two cases:
+  - `every PR-triggered workflow declares a concurrency group (#258)` —
+    parses each `.github/workflows/*.yml`, skips `deploy.yml`, and for
+    every workflow that triggers on `pull_request` asserts the
+    `concurrency.group` references both `github.workflow` and
+    `github.ref` and `cancel-in-progress` is `true`.
+  - `deploy.yml keeps its Pages-serialising concurrency policy (#258)` —
+    asserts `group: pages` and `cancel-in-progress: false` so the Pages
+    pipeline is not accidentally regressed by future edits.
+- Confirmed the new test failed against `main` before the workflow edits
+  and passes after.
+- `./quality.sh` passes: 726 tests, 0 failures.

--- a/tests/workflow_concurrency_test.ts
+++ b/tests/workflow_concurrency_test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for the workflow concurrency policy (#258).
+ *
+ * Every PR-triggered workflow in `.github/workflows/` must declare a
+ * workflow-level `concurrency:` block so that superseded runs are cancelled
+ * when a contributor pushes new commits to a PR in quick succession. Without
+ * this, older runs keep churning the same `deno fmt` / `deno lint` /
+ * `deno test` / Semgrep work, wasting runner minutes and confusing the PR
+ * Checks panel about "current status".
+ *
+ * The canonical group key is `${{ github.workflow }}-${{ github.ref }}` with
+ * `cancel-in-progress: true`.
+ *
+ * `deploy.yml` is intentionally exempt — it keys its concurrency on `"pages"`
+ * with `cancel-in-progress: false` so Pages deploys serialise correctly.
+ */
+
+import { parse as parseYaml } from "@std/yaml";
+import { assert, assertEquals } from "./test_helpers.ts";
+
+interface ConcurrencyBlock {
+  group?: string;
+  "cancel-in-progress"?: boolean;
+}
+
+interface Workflow {
+  on?: Record<string, unknown> | string | string[];
+  concurrency?: ConcurrencyBlock | string;
+}
+
+const WORKFLOWS_DIR = new URL("../.github/workflows/", import.meta.url);
+
+// deploy.yml deliberately uses a different concurrency policy
+// (group: "pages", cancel-in-progress: false). It serialises Pages
+// deploys instead of cancelling them.
+const EXEMPT_WORKFLOWS = new Set(["deploy.yml"]);
+
+async function listWorkflowFiles(): Promise<string[]> {
+  const files: string[] = [];
+  for await (const entry of Deno.readDir(WORKFLOWS_DIR)) {
+    if (!entry.isFile) continue;
+    if (!entry.name.endsWith(".yml") && !entry.name.endsWith(".yaml")) continue;
+    files.push(entry.name);
+  }
+  files.sort();
+  return files;
+}
+
+async function loadWorkflow(name: string): Promise<Workflow> {
+  const url = new URL(name, WORKFLOWS_DIR);
+  const text = await Deno.readTextFile(url);
+  return parseYaml(text) as Workflow;
+}
+
+function isPrTriggered(wf: Workflow): boolean {
+  const triggers = wf.on;
+  if (!triggers) return false;
+  if (typeof triggers === "string") return triggers === "pull_request";
+  if (Array.isArray(triggers)) return triggers.includes("pull_request");
+  return "pull_request" in (triggers as Record<string, unknown>);
+}
+
+Deno.test(
+  "every PR-triggered workflow declares a concurrency group (#258)",
+  async () => {
+    const files = await listWorkflowFiles();
+    assert(files.length > 0, "expected at least one workflow file");
+
+    const failures: string[] = [];
+    let checked = 0;
+    for (const file of files) {
+      if (EXEMPT_WORKFLOWS.has(file)) continue;
+      const wf = await loadWorkflow(file);
+      if (!isPrTriggered(wf)) continue;
+      checked++;
+
+      const conc = wf.concurrency;
+      if (!conc || typeof conc !== "object") {
+        failures.push(
+          `${file}: missing top-level concurrency block (expected ` +
+            `group + cancel-in-progress: true)`,
+        );
+        continue;
+      }
+      const group = conc.group ?? "";
+      if (
+        !group.includes("github.workflow") || !group.includes("github.ref")
+      ) {
+        failures.push(
+          `${file}: concurrency.group must reference both github.workflow ` +
+            `and github.ref, got '${group}'`,
+        );
+      }
+      if (conc["cancel-in-progress"] !== true) {
+        failures.push(
+          `${file}: concurrency.cancel-in-progress must be true, got ` +
+            `${conc["cancel-in-progress"]}`,
+        );
+      }
+    }
+
+    assert(
+      checked > 0,
+      "expected at least one PR-triggered workflow to validate",
+    );
+    assert(
+      failures.length === 0,
+      `PR-triggered workflows missing or with invalid concurrency:\n  ${
+        failures.join("\n  ")
+      }`,
+    );
+  },
+);
+
+Deno.test(
+  "deploy.yml keeps its Pages-serialising concurrency policy (#258)",
+  async () => {
+    const wf = await loadWorkflow("deploy.yml");
+    const conc = wf.concurrency;
+    assert(
+      conc && typeof conc === "object",
+      "deploy.yml must declare a concurrency block",
+    );
+    assertEquals(
+      (conc as ConcurrencyBlock).group,
+      "pages",
+      "deploy.yml concurrency.group must be 'pages'",
+    );
+    assertEquals(
+      (conc as ConcurrencyBlock)["cancel-in-progress"],
+      false,
+      "deploy.yml must NOT cancel in-progress deploys",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Added workflow-level `concurrency:` blocks to every PR-triggered workflow in
`.github/workflows/` so superseded runs are cancelled when a contributor
pushes new commits to a PR. Each block keys on
{% raw %}`${{ github.workflow }}-${{ github.ref }}`{% endraw %} with
`cancel-in-progress: true` — the canonical pattern. The Pages
deploy workflow keeps its existing `group: "pages"` /
`cancel-in-progress: false` policy because Pages deploys must serialise.
Closes #258.

The issue listed `ci.yml`, but it does not exist in this repo — it was
consolidated into `deno-quality.yml` under Issue #259, so that file picked
up the concurrency block in its place. `upgrade-dependencies.yml` is
schedule / `workflow_dispatch` only (not PR-triggered) so it is not in
scope.

## Workflows updated

- `a11y.yml`
- `deno-quality.yml`
- `dependency-review.yml`
- `gitleaks.yml`
- `markdown-lint.yml`
- `semgrep.yml`
- `semver-bump.yml`
- `shellcheck.yml`

`deploy.yml` is unchanged.

## Evidence

Backend / CI-config change with no UI surface, so no screenshot. Behaviour
is verified by the new test in `tests/workflow_concurrency_test.ts`, which
parses every workflow YAML and asserts that PR-triggered ones declare the
canonical concurrency block while `deploy.yml` keeps its Pages-serialising
policy.

```mermaid
sequenceDiagram
    participant Dev as Contributor
    participant GH as GitHub
    participant Run1 as Run #N (older)
    participant Run2 as Run #N+1 (latest)
    Dev->>GH: push commit A
    GH->>Run1: start workflow
    Dev->>GH: push commit B (supersedes A)
    GH->>Run2: start workflow
    GH-->>Run1: cancel-in-progress (same group)
    Run2->>Dev: feedback on latest commit
```

## Test Plan

- Added `tests/workflow_concurrency_test.ts` with two cases:
  - `every PR-triggered workflow declares a concurrency group (#258)` —
    parses each `.github/workflows/*.yml`, skips `deploy.yml`, and for
    every workflow that triggers on `pull_request` asserts the
    `concurrency.group` references both `github.workflow` and
    `github.ref` and `cancel-in-progress` is `true`.
  - `deploy.yml keeps its Pages-serialising concurrency policy (#258)` —
    asserts `group: pages` and `cancel-in-progress: false` so the Pages
    pipeline is not accidentally regressed by future edits.
- Confirmed the new test failed against `main` before the workflow edits
  and passes after.
- `./quality.sh` passes: 726 tests, 0 failures.



## Milestone
This PR is part of the **audit issues** milestone and targets the `milestone/audit-issues` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-258 -->