### PR TITLE
Add set -Eeuo pipefail to a11y readiness loop (#260)

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Serve docs/ in the background
         run: |
+          set -Eeuo pipefail
           http-server ./docs -p 8080 -a 127.0.0.1 --silent &
           # Wait briefly for the server to come up; fail fast if it does not.
           for i in 1 2 3 4 5 6 7 8 9 10; do

--- a/docs/archive/pr-summaries/pr-summary-258.md
+++ b/docs/archive/pr-summaries/pr-summary-258.md
@@ -1,19 +1,17 @@
 ## Summary
 
 Added workflow-level `concurrency:` blocks to every PR-triggered workflow in
-`.github/workflows/` so superseded runs are cancelled when a contributor
-pushes new commits to a PR. Each block keys on
-{% raw %}`${{ github.workflow }}-${{ github.ref }}`{% endraw %} with
-`cancel-in-progress: true` — the canonical pattern. The Pages
-deploy workflow keeps its existing `group: "pages"` /
-`cancel-in-progress: false` policy because Pages deploys must serialise.
-Closes #258.
+`.github/workflows/` so superseded runs are cancelled when a contributor pushes
+new commits to a PR. Each block keys on {% raw
+%}`${{ github.workflow }}-${{ github.ref }}`{% endraw %} with
+`cancel-in-progress: true` — the canonical pattern. The Pages deploy workflow
+keeps its existing `group: "pages"` / `cancel-in-progress: false` policy because
+Pages deploys must serialise. Closes #258.
 
 The issue listed `ci.yml`, but it does not exist in this repo — it was
-consolidated into `deno-quality.yml` under Issue #259, so that file picked
-up the concurrency block in its place. `upgrade-dependencies.yml` is
-schedule / `workflow_dispatch` only (not PR-triggered) so it is not in
-scope.
+consolidated into `deno-quality.yml` under Issue #259, so that file picked up
+the concurrency block in its place. `upgrade-dependencies.yml` is schedule /
+`workflow_dispatch` only (not PR-triggered) so it is not in scope.
 
 ## Workflows updated
 
@@ -30,11 +28,10 @@ scope.
 
 ## Evidence
 
-Backend / CI-config change with no UI surface, so no screenshot. Behaviour
-is verified by the new test in `tests/workflow_concurrency_test.ts`, which
-parses every workflow YAML and asserts that PR-triggered ones declare the
-canonical concurrency block while `deploy.yml` keeps its Pages-serialising
-policy.
+Backend / CI-config change with no UI surface, so no screenshot. Behaviour is
+verified by the new test in `tests/workflow_concurrency_test.ts`, which parses
+every workflow YAML and asserts that PR-triggered ones declare the canonical
+concurrency block while `deploy.yml` keeps its Pages-serialising policy.
 
 ```mermaid
 sequenceDiagram
@@ -53,14 +50,13 @@ sequenceDiagram
 ## Test Plan
 
 - Added `tests/workflow_concurrency_test.ts` with two cases:
-  - `every PR-triggered workflow declares a concurrency group (#258)` —
-    parses each `.github/workflows/*.yml`, skips `deploy.yml`, and for
-    every workflow that triggers on `pull_request` asserts the
-    `concurrency.group` references both `github.workflow` and
-    `github.ref` and `cancel-in-progress` is `true`.
-  - `deploy.yml keeps its Pages-serialising concurrency policy (#258)` —
-    asserts `group: pages` and `cancel-in-progress: false` so the Pages
-    pipeline is not accidentally regressed by future edits.
-- Confirmed the new test failed against `main` before the workflow edits
-  and passes after.
+  - `every PR-triggered workflow declares a concurrency group (#258)` — parses
+    each `.github/workflows/*.yml`, skips `deploy.yml`, and for every workflow
+    that triggers on `pull_request` asserts the `concurrency.group` references
+    both `github.workflow` and `github.ref` and `cancel-in-progress` is `true`.
+  - `deploy.yml keeps its Pages-serialising concurrency policy (#258)` — asserts
+    `group: pages` and `cancel-in-progress: false` so the Pages pipeline is not
+    accidentally regressed by future edits.
+- Confirmed the new test failed against `main` before the workflow edits and
+  passes after.
 - `./quality.sh` passes: 726 tests, 0 failures.

--- a/docs/archive/pr-summaries/pr-summary-260.md
+++ b/docs/archive/pr-summaries/pr-summary-260.md
@@ -1,0 +1,41 @@
+## Summary
+
+Added `set -Eeuo pipefail` to the "Serve docs/ in the background" step in
+`.github/workflows/a11y.yml`, matching the convention already used in
+`semver-bump.yml`. Without strict bash flags, a typo'd `${VAR}` expansion would
+silently become an empty string, and a failing `curl | grep` chain inside the
+readiness loop would be swallowed by the pipeline — both of which can wedge the
+loop and produce a confusing downstream `pa11y-ci` failure. Closes #260.
+
+## Evidence
+
+Backend / CI-config change with no UI surface — no screenshot. Behaviour is
+verified by a new regression test in `tests/a11y_workflow_test.ts` which parses
+the workflow YAML, locates the http-server readiness step, and asserts its
+`run:` block begins with `set -euo pipefail` (or `-Eeuo`). The test was
+confirmed to fail against the unfixed workflow and to pass after the edit.
+
+```mermaid
+flowchart LR
+    A[Serve docs/ step] --> B{set -Eeuo pipefail}
+    B --> C[http-server &amp; in background]
+    C --> D[curl readiness loop x10]
+    D -- ready --> E[exit 0 → pa11y-ci runs]
+    D -- timeout --> F[exit 1 → job fails fast]
+```
+
+## Test Plan
+
+- Added
+  `a11y workflow http-server readiness loop uses strict bash flags
+  (#260)` in
+  `tests/a11y_workflow_test.ts` — finds the http-server step and asserts its
+  bash starts with `set -euo pipefail` (or `-Eeuo`).
+- Confirmed the new test fails against the milestone branch before the workflow
+  edit and passes after.
+- `./quality.sh` passes locally (727 tests, 0 failures).
+
+## Deno regression avoided
+
+Stayed within the existing Deno test harness — the new regression test is a Deno
+YAML parser check, not a Node-based linter.

--- a/tests/a11y_workflow_test.ts
+++ b/tests/a11y_workflow_test.ts
@@ -115,6 +115,30 @@ Deno.test("a11y workflow pins third-party actions to commit SHAs", async () => {
   }
 });
 
+Deno.test("a11y workflow http-server readiness loop uses strict bash flags (#260)", async () => {
+  const wf = await loadWorkflow();
+  const job = wf.jobs?.a11y;
+  const steps = job?.steps ?? [];
+
+  const serveStep = steps.find((s) =>
+    (s.run ?? "").includes("http-server") &&
+    (s.run ?? "").includes("127.0.0.1:8080")
+  );
+  assert(
+    serveStep,
+    "workflow must declare a step that backgrounds http-server on 127.0.0.1:8080",
+  );
+
+  const run = serveStep!.run ?? "";
+  // Match the semver-bump.yml convention (`set -Eeuo pipefail`) but accept the
+  // suggested `set -euo pipefail` too — both close the failure modes the audit
+  // flagged (typo'd ${VAR} expansions, swallowed pipeline failures).
+  assert(
+    /^\s*set\s+-E?euo\s+pipefail\b/m.test(run),
+    "Serve docs/ step must begin its bash with `set -euo pipefail` (or `-Eeuo`) before backgrounding http-server",
+  );
+});
+
 Deno.test("pa11y-ci config exists and is valid JSON", async () => {
   const text = await Deno.readTextFile(CONFIG_PATH);
   const parsed = JSON.parse(text);


### PR DESCRIPTION
## Summary

Added `set -Eeuo pipefail` to the "Serve docs/ in the background" step in
`.github/workflows/a11y.yml`, matching the convention already used in
`semver-bump.yml`. Without strict bash flags, a typo'd `${VAR}` expansion would
silently become an empty string, and a failing `curl | grep` chain inside the
readiness loop would be swallowed by the pipeline — both of which can wedge the
loop and produce a confusing downstream `pa11y-ci` failure. Closes #260.

## Evidence

Backend / CI-config change with no UI surface — no screenshot. Behaviour is
verified by a new regression test in `tests/a11y_workflow_test.ts` which parses
the workflow YAML, locates the http-server readiness step, and asserts its
`run:` block begins with `set -euo pipefail` (or `-Eeuo`). The test was
confirmed to fail against the unfixed workflow and to pass after the edit.

```mermaid
flowchart LR
    A[Serve docs/ step] --> B{set -Eeuo pipefail}
    B --> C[http-server &amp; in background]
    C --> D[curl readiness loop x10]
    D -- ready --> E[exit 0 → pa11y-ci runs]
    D -- timeout --> F[exit 1 → job fails fast]
```

## Test Plan

- Added
  `a11y workflow http-server readiness loop uses strict bash flags
  (#260)` in
  `tests/a11y_workflow_test.ts` — finds the http-server step and asserts its
  bash starts with `set -euo pipefail` (or `-Eeuo`).
- Confirmed the new test fails against the milestone branch before the workflow
  edit and passes after.
- `./quality.sh` passes locally (727 tests, 0 failures).

## Deno regression avoided

Stayed within the existing Deno test harness — the new regression test is a Deno
YAML parser check, not a Node-based linter.



## Milestone
This PR is part of the **audit issues** milestone and targets the `milestone/audit-issues` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-260 -->