### PR TITLE
test: drop wall-clock timing assertion in cycle-walk test (#264)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-264.md
+++ b/docs/archive/pr-summaries/pr-summary-264.md
@@ -1,0 +1,27 @@
+## Summary
+
+Removed the wall-clock timing assertion from `tests/observation_contributions_test.ts` ("cycles are finite and deterministic"). The 2000ms ceiling was a flaky performance budget masquerading as a termination check — termination is already covered by the Deno test runner's own timeout and by the behavioural assertions on `res.inputs` further down the test. Performance budgets belong in a benchmark, not a unit test. Closes #264.
+
+## Evidence
+
+This is a test-only CLI change — no UI surface to screenshot.
+
+Verification:
+
+- `deno test tests/observation_contributions_test.ts` — all 6 tests pass (the cycle test runs in 0ms locally).
+- `./quality.sh` — full suite: 727 passed, 0 failed.
+
+The behavioural guarantees the test was always meant to verify remain intact:
+
+- `assertEquals(res.inputs.length, 1, ...)` — only `input-0` is reachable.
+- `assertEquals(res.inputs[0].uuid, "input-0")` — correct input identified.
+- `approx(res.inputs[0].score, 1, 1e-9)` — full share attributed.
+- Determinism check — second walk returns identical output.
+
+A real infinite loop would never reach those assertions; the Deno runner would kill the test first.
+
+## Test Plan
+
+- Modified `tests/observation_contributions_test.ts` — deleted the `performance.now()` start/end measurement and the `elapsedMs < 2000` assertion. Kept every behavioural assertion in the same test. Added a comment explaining why the timing check was removed and pointing at issue #264.
+- Ran the affected test file in isolation — 6/6 pass.
+- Ran the full `./quality.sh` gate — 727/727 pass.

--- a/tests/observation_contributions_test.ts
+++ b/tests/observation_contributions_test.ts
@@ -111,20 +111,14 @@ Deno.test("observation contributions: cycles are finite and deterministic", () =
     ],
   };
 
-  const start = performance.now();
+  // Termination is enforced by the Deno test runner's own timeout — a real
+  // infinite loop would never reach the assertions below. Wall-clock timing
+  // budgets belong in a benchmark, not in a unit test (see issue #264).
   const res = computeTopContributingInputs({
     focusUuid: "output-0",
     getInboundEdges: inboundLookup(inbound),
     exhaustive: true,
   });
-  const elapsedMs = performance.now() - start;
-
-  // Termination: well below any sane unit-test budget. A real infinite loop
-  // would never get here, but this guards against accidental slowdowns too.
-  assert(
-    elapsedMs < 2000,
-    `walk on a cycle should be fast; took ${elapsedMs.toFixed(1)}ms`,
-  );
 
   // Only input-0 is reachable; hidden-B is a dead-end cycle that loops back
   // through hidden-A (a node already on the path) so it contributes 0.


### PR DESCRIPTION
## Summary

Removed the wall-clock timing assertion from `tests/observation_contributions_test.ts` ("cycles are finite and deterministic"). The 2000ms ceiling was a flaky performance budget masquerading as a termination check — termination is already covered by the Deno test runner's own timeout and by the behavioural assertions on `res.inputs` further down the test. Performance budgets belong in a benchmark, not a unit test. Closes #264.

## Evidence

This is a test-only CLI change — no UI surface to screenshot.

Verification:

- `deno test tests/observation_contributions_test.ts` — all 6 tests pass (the cycle test runs in 0ms locally).
- `./quality.sh` — full suite: 727 passed, 0 failed.

The behavioural guarantees the test was always meant to verify remain intact:

- `assertEquals(res.inputs.length, 1, ...)` — only `input-0` is reachable.
- `assertEquals(res.inputs[0].uuid, "input-0")` — correct input identified.
- `approx(res.inputs[0].score, 1, 1e-9)` — full share attributed.
- Determinism check — second walk returns identical output.

A real infinite loop would never reach those assertions; the Deno runner would kill the test first.

## Test Plan

- Modified `tests/observation_contributions_test.ts` — deleted the `performance.now()` start/end measurement and the `elapsedMs < 2000` assertion. Kept every behavioural assertion in the same test. Added a comment explaining why the timing check was removed and pointing at issue #264.
- Ran the affected test file in isolation — 6/6 pass.
- Ran the full `./quality.sh` gate — 727/727 pass.



## Milestone
This PR is part of the **audit issues** milestone and targets the `milestone/audit-issues` feature branch.

---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-264 -->