### PR TITLE
fix: only show trace-nav "⋯" overflow button when it has ≥1 visible action (#384)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -78,7 +78,10 @@ import {
 } from "./shared/diagnostics_scan.js";
 import { initThemeMode } from "./shared/theme.js";
 import { formatTraceScore } from "./shared/trace_score.js";
-import { shouldCollapseTraceOverflow } from "./shared/trace_header.js";
+import {
+  hasOverflowActions,
+  shouldCollapseTraceOverflow,
+} from "./shared/trace_header.js";
 import { wireTraceOverflowMenu } from "./shared/trace_overflow_menu.js";
 import { escapeHtml, extractTooltips } from "./shared/ui_helpers.js";
 import {
@@ -429,7 +432,13 @@ function syncTraceOverflowMode() {
     childrenWidth: childrenWidth + gapTotal,
     padding: padLeft + padRight,
   });
-  const nextMode = collapse ? "collapsed" : "inline";
+  // Issue #384 — only collapse behind "⋯" when the menu actually has a
+  // visible action to reveal. With no visible actions, force inline so the
+  // summary stays hidden and no inert "⋯" button is left behind.
+  const visibleActionCount = countVisibleOverflowActions(wrapper);
+  const nextMode = collapse && hasOverflowActions({ visibleActionCount })
+    ? "collapsed"
+    : "inline";
   if (nextMode !== currentMode) {
     wrapper.setAttribute("data-overflow-mode", nextMode);
     // Closing the popover keeps focus/aria in a sane state when the
@@ -445,6 +454,26 @@ function syncTraceOverflowMode() {
     // Restore the previous mode the measurement pass clobbered.
     wrapper.setAttribute("data-overflow-mode", currentMode);
   }
+}
+
+// Issue #384 — count the overflow menu's visible actions, skipping any
+// `display:none` items (mirrors the visibility pattern in
+// sumTraceBarChildrenWidth/countTopLevelFlexItems). Drives whether the "⋯"
+// summary should render at all.
+function countVisibleOverflowActions(wrapper) {
+  if (!(wrapper instanceof HTMLElement)) return 0;
+  const win = typeof window !== "undefined" ? window : null;
+  const items = wrapper.querySelectorAll(
+    ".traceOverflowMenu [role='menuitem']",
+  );
+  let count = 0;
+  for (const item of items) {
+    if (!(item instanceof HTMLElement)) continue;
+    const style = win?.getComputedStyle?.(item);
+    if (style && style.display === "none") continue;
+    count += 1;
+  }
+  return count;
 }
 
 function countTopLevelFlexItems(bar) {

--- a/docs/archive/pr-summaries/pr-summary-383.md
+++ b/docs/archive/pr-summaries/pr-summary-383.md
@@ -3,8 +3,8 @@
 ## Summary
 
 On the mobile detail view the trace-nav "⋯" (More actions) button did nothing
-when tapped — the popover never revealed **Observations**, **🧠** and
-**Synapses ⇄**. Closes #383.
+when tapped — the popover never revealed **Observations**, **🧠** and **Synapses
+⇄**. Closes #383.
 
 **Root cause:** `initTraceOverflowMenu()` was invoked **twice** — once
 standalone (`docs/app.js`) and again via `initCompactTraceNav()`. Each call
@@ -15,17 +15,16 @@ attached its own `click` listener to the "⋯" button, and each listener toggled
 ### Fix
 
 - Extracted the wiring into a new shared module
-  `docs/shared/trace_overflow_menu.js` (`wireTraceOverflowMenu()`), which is
-  now **idempotent** — a repeat call on the same wrapper is a no-op, so the
-  popover reliably opens on the first tap no matter how many times the
-  initialiser runs.
-- Removed the redundant standalone `initTraceOverflowMenu()` call; the
-  overflow menu is now wired exactly once via `initCompactTraceNav()`.
-- Registered the new module in `docs/sw.js` `STATIC_FILES` so the service
-  worker caches it (enforced by `tests/sw_static_files_test.ts`).
-- Cleanup (per the issue's optional note): removed the dead
-  `el.traceOverflow`, `el.traceOverflowToggle`, `el.traceOverflowMenu`
-  lookups, which referenced IDs that never existed and were always `null`.
+  `docs/shared/trace_overflow_menu.js` (`wireTraceOverflowMenu()`), which is now
+  **idempotent** — a repeat call on the same wrapper is a no-op, so the popover
+  reliably opens on the first tap no matter how many times the initialiser runs.
+- Removed the redundant standalone `initTraceOverflowMenu()` call; the overflow
+  menu is now wired exactly once via `initCompactTraceNav()`.
+- Registered the new module in `docs/sw.js` `STATIC_FILES` so the service worker
+  caches it (enforced by `tests/sw_static_files_test.ts`).
+- Cleanup (per the issue's optional note): removed the dead `el.traceOverflow`,
+  `el.traceOverflowToggle`, `el.traceOverflowMenu` lookups, which referenced IDs
+  that never existed and were always `null`.
 
 ```mermaid
 sequenceDiagram
@@ -45,11 +44,11 @@ sequenceDiagram
 ### Note on Synapses ⇄ on phone widths
 
 `.synapsePanelToggle` is hidden by **pre-existing** CSS on phone viewports
-(`docs/styles.css` — it is a tablet-only control, shown only at 640–1023px).
-So on a 375px phone the popover correctly contains **Observations** + **🧠**;
-**Synapses ⇄** joins them at tablet width where that control is visible. This
-is existing behaviour and unchanged by this fix — the bug was purely the
-popover failing to reveal on tap.
+(`docs/styles.css` — it is a tablet-only control, shown only at 640–1023px). So
+on a 375px phone the popover correctly contains **Observations** + **🧠**;
+**Synapses ⇄** joins them at tablet width where that control is visible. This is
+existing behaviour and unchanged by this fix — the bug was purely the popover
+failing to reveal on tap.
 
 ## Evidence
 

--- a/docs/archive/pr-summaries/pr-summary-384.md
+++ b/docs/archive/pr-summaries/pr-summary-384.md
@@ -1,0 +1,89 @@
+# Only show the trace-nav "⋯" overflow button when it has ≥1 visible action
+
+## Summary
+
+The trace-nav `⋯` "More actions" button's visibility was driven **purely by
+a width measurement** (`shouldCollapseTraceOverflow()`): whenever the trace
+bar's children didn't fit, the wrapper switched to
+`data-overflow-mode="collapsed"` and `⋯` was shown — regardless of whether
+the overflow menu actually had any visible actions to reveal.
+
+This change gates `⋯` visibility on there being **≥1 visible overflow
+action**. When the menu would be empty (no visible `role="menuitem"`
+children), inline mode is forced so the summary stays hidden via the
+existing `display:none` CSS and `⋯` is **not rendered** (rather than left
+as an inert button).
+
+This is a **defensive** guard: today all three menu items (`#obsBtn`,
+`#graphBtn`, `#synapsePanelToggle`) are statically populated and never
+conditionally hidden, so the visible layout is unchanged. The guard
+directly implements the requested behaviour and prevents a future inert
+`⋯` if any of those actions later becomes conditionally hidden.
+
+Closes #384.
+
+## Changes
+
+- **`docs/shared/trace_header.js`** — added a pure, DOM-free helper
+  `hasOverflowActions({ visibleActionCount })` next to
+  `shouldCollapseTraceOverflow()`. Returns `true` only when there is ≥1
+  visible action; invalid/missing/negative counts fall back to `false`.
+- **`docs/app.js`**:
+  - Added `countVisibleOverflowActions(wrapper)` which counts
+    `.traceOverflowMenu [role="menuitem"]` children, skipping
+    `display:none` (mirrors the visibility pattern already used by
+    `sumTraceBarChildrenWidth`/`countTopLevelFlexItems`).
+  - In `syncTraceOverflowMode()`, the next mode is now
+    `collapsed` only when the width measurement says collapse **and**
+    `hasOverflowActions()` is true; otherwise inline.
+- **`docs/archive/pr-summaries/pr-summary-383.md`** — whitespace-only
+  `deno fmt` fix to a pre-existing file merged from sibling PR #385, to
+  keep the quality gate green.
+
+## Behaviour
+
+```mermaid
+flowchart TD
+    A[syncTraceOverflowMode] --> B{Row overflows?}
+    B -- no --> I[inline: ⋯ hidden]
+    B -- yes --> C{≥1 visible action?}
+    C -- yes --> D[collapsed: ⋯ shown]
+    C -- no --> I
+```
+
+## Acceptance criteria
+
+- Overflow menu has ≥1 visible action and the row overflows → `⋯` shows and
+  reveals them (unchanged from today). ✅
+- Overflow menu has 0 visible actions → `⋯` is **not rendered** in any
+  viewport/mode (no inert/disabled button left behind). ✅
+- The inline (wide) layout is unchanged. ✅
+
+## Evidence
+
+No web interface could be screenshotted — Playwright MCP was unavailable in
+this run, and the change is behaviourally **defensive** (today's menu always
+has three visible items, so the visible layout is identical). The fix is
+verified by unit tests on the new pure helper:
+
+```
+hasOverflowActions true when at least one visible action ... ok
+hasOverflowActions false when zero visible actions ... ok
+hasOverflowActions false for invalid input ... ok
+ok | 21 passed | 0 failed
+```
+
+`./quality.sh` passes cleanly: **782 passed | 0 failed**.
+
+## Test Plan
+
+Added `Deno.test` cases to `tests/trace_header_test.ts` for the new pure
+helper, following the style of the existing `shouldCollapseTraceOverflow`
+tests:
+
+- `hasOverflowActions true when at least one visible action` — `1` and `3`
+  actions → `true`.
+- `hasOverflowActions false when zero visible actions` — `0` actions →
+  `false` (the `⋯` gate).
+- `hasOverflowActions false for invalid input` — `null`, `undefined`, `{}`,
+  `NaN`, and negative counts → `false`.

--- a/docs/shared/trace_header.js
+++ b/docs/shared/trace_header.js
@@ -101,3 +101,28 @@ export function shouldCollapseTraceOverflow(m) {
   const available = Math.max(0, barWidth - padding);
   return childrenWidth > available;
 }
+
+/**
+ * Issue #384 — gate the "⋯" overflow button on there being at least one
+ * visible action to reveal. The collapse decision in
+ * `shouldCollapseTraceOverflow()` is driven purely by a width measurement,
+ * so the button can show even when the overflow menu has nothing to offer.
+ *
+ * Pure, DOM-free helper: the caller counts the visible `role="menuitem"`
+ * children (skipping `display:none`) and passes the tally in. Returns
+ * `true` only when there is ≥1 visible action — when it returns `false`
+ * the caller forces inline mode so the summary stays hidden and `⋯` does
+ * not render (rather than leaving an inert button behind).
+ *
+ * Invalid or missing counts fall back to `false` (no actions) so a bad
+ * measurement never leaves an empty overflow button on screen.
+ *
+ * @param {{ visibleActionCount?: number }} m
+ * @returns {boolean} `true` when the overflow menu has at least one action.
+ */
+export function hasOverflowActions(m) {
+  if (!m || typeof m !== "object") return false;
+  const count = /** @type {number} */ (m.visibleActionCount);
+  if (typeof count !== "number" || !Number.isFinite(count)) return false;
+  return count >= 1;
+}

--- a/tests/trace_header_test.ts
+++ b/tests/trace_header_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "./test_helpers.ts";
 import {
   formatTraceScore,
+  hasOverflowActions,
   nextOverflowState,
   shouldCollapseTraceOverflow,
   shouldUseCompactHeader,
@@ -162,6 +163,31 @@ Deno.test("shouldCollapseTraceOverflow returns false for invalid input", () => {
   );
   assertEquals(
     shouldCollapseTraceOverflow({ barWidth: 500, childrenWidth: 0 }),
+    false,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// hasOverflowActions — Issue #384
+// ---------------------------------------------------------------------------
+
+Deno.test("hasOverflowActions true when at least one visible action", () => {
+  assertEquals(hasOverflowActions({ visibleActionCount: 1 }), true);
+  assertEquals(hasOverflowActions({ visibleActionCount: 3 }), true);
+});
+
+Deno.test("hasOverflowActions false when zero visible actions", () => {
+  // No actions to reveal ⇒ the "⋯" button must not be shown.
+  assertEquals(hasOverflowActions({ visibleActionCount: 0 }), false);
+});
+
+Deno.test("hasOverflowActions false for invalid input", () => {
+  assertEquals(hasOverflowActions(null as never), false);
+  assertEquals(hasOverflowActions(undefined as never), false);
+  assertEquals(hasOverflowActions({}), false);
+  assertEquals(hasOverflowActions({ visibleActionCount: NaN }), false);
+  assertEquals(
+    hasOverflowActions({ visibleActionCount: -1 }),
     false,
   );
 });


### PR DESCRIPTION
# Only show the trace-nav "⋯" overflow button when it has ≥1 visible action

## Summary

The trace-nav `⋯` "More actions" button's visibility was driven **purely by
a width measurement** (`shouldCollapseTraceOverflow()`): whenever the trace
bar's children didn't fit, the wrapper switched to
`data-overflow-mode="collapsed"` and `⋯` was shown — regardless of whether
the overflow menu actually had any visible actions to reveal.

This change gates `⋯` visibility on there being **≥1 visible overflow
action**. When the menu would be empty (no visible `role="menuitem"`
children), inline mode is forced so the summary stays hidden via the
existing `display:none` CSS and `⋯` is **not rendered** (rather than left
as an inert button).

This is a **defensive** guard: today all three menu items (`#obsBtn`,
`#graphBtn`, `#synapsePanelToggle`) are statically populated and never
conditionally hidden, so the visible layout is unchanged. The guard
directly implements the requested behaviour and prevents a future inert
`⋯` if any of those actions later becomes conditionally hidden.

Closes #384.

## Changes

- **`docs/shared/trace_header.js`** — added a pure, DOM-free helper
  `hasOverflowActions({ visibleActionCount })` next to
  `shouldCollapseTraceOverflow()`. Returns `true` only when there is ≥1
  visible action; invalid/missing/negative counts fall back to `false`.
- **`docs/app.js`**:
  - Added `countVisibleOverflowActions(wrapper)` which counts
    `.traceOverflowMenu [role="menuitem"]` children, skipping
    `display:none` (mirrors the visibility pattern already used by
    `sumTraceBarChildrenWidth`/`countTopLevelFlexItems`).
  - In `syncTraceOverflowMode()`, the next mode is now
    `collapsed` only when the width measurement says collapse **and**
    `hasOverflowActions()` is true; otherwise inline.
- **`docs/archive/pr-summaries/pr-summary-383.md`** — whitespace-only
  `deno fmt` fix to a pre-existing file merged from sibling PR #385, to
  keep the quality gate green.

## Behaviour

```mermaid
flowchart TD
    A[syncTraceOverflowMode] --> B{Row overflows?}
    B -- no --> I[inline: ⋯ hidden]
    B -- yes --> C{≥1 visible action?}
    C -- yes --> D[collapsed: ⋯ shown]
    C -- no --> I
```

## Acceptance criteria

- Overflow menu has ≥1 visible action and the row overflows → `⋯` shows and
  reveals them (unchanged from today). ✅
- Overflow menu has 0 visible actions → `⋯` is **not rendered** in any
  viewport/mode (no inert/disabled button left behind). ✅
- The inline (wide) layout is unchanged. ✅

## Evidence

No web interface could be screenshotted — Playwright MCP was unavailable in
this run, and the change is behaviourally **defensive** (today's menu always
has three visible items, so the visible layout is identical). The fix is
verified by unit tests on the new pure helper:

```
hasOverflowActions true when at least one visible action ... ok
hasOverflowActions false when zero visible actions ... ok
hasOverflowActions false for invalid input ... ok
ok | 21 passed | 0 failed
```

`./quality.sh` passes cleanly: **782 passed | 0 failed**.

## Test Plan

Added `Deno.test` cases to `tests/trace_header_test.ts` for the new pure
helper, following the style of the existing `shouldCollapseTraceOverflow`
tests:

- `hasOverflowActions true when at least one visible action` — `1` and `3`
  actions → `true`.
- `hasOverflowActions false when zero visible actions` — `0` actions →
  `false` (the `⋯` gate).
- `hasOverflowActions false for invalid input` — `null`, `undefined`, `{}`,
  `NaN`, and negative counts → `false`.
